### PR TITLE
Fill test gaps: error paths, ctx cancellation, concurrency, restart

### DIFF
--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -485,4 +486,123 @@ func TestRPC_SignRawTransactionWithWallet(t *testing.T) {
 	}
 
 	t.Logf("Transaction confirmed with %d confirmations", confirmedUTXO.Confirmations)
+}
+
+// TestRPC_Warp_ValidationErrors covers the validation guards in WarpContext
+// (regtest.go:821-826 era; now mining.go). These paths short-circuit before
+// any RPC call, so no live node is required.
+func TestRPC_Warp_ValidationErrors(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("failed to create regtest: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Cleanup() })
+
+	cases := []struct {
+		name   string
+		blocks int64
+		miner  string
+	}{
+		{"zero_blocks", 0, "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl"},
+		{"negative_blocks", -1, "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl"},
+		{"empty_miner", 1, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := rt.Warp(tc.blocks, tc.miner); err == nil {
+				t.Errorf("expected validation error for blocks=%d miner=%q, got nil", tc.blocks, tc.miner)
+			}
+		})
+	}
+}
+
+// TestRPC_SendToAddress_ValidationErrors covers SendToAddressContext's input
+// guards. As with Warp, these short-circuit before any RPC call.
+func TestRPC_SendToAddress_ValidationErrors(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("failed to create regtest: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Cleanup() })
+
+	cases := []struct {
+		name string
+		addr string
+		sats int64
+	}{
+		{"zero_sats", "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl", 0},
+		{"negative_sats", "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl", -1},
+		{"empty_address", "", 1000},
+		{"malformed_address", "definitely-not-an-address", 1000},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := rt.SendToAddress(tc.addr, tc.sats); err == nil {
+				t.Errorf("expected validation error for addr=%q sats=%d, got nil", tc.addr, tc.sats)
+			}
+		})
+	}
+}
+
+// TestRPC_Concurrent_WarpAndSend stresses the dual-mutex pattern (mu for
+// lifecycle, clientMu for client access) by interleaving Warp (which mines
+// blocks) with SendToAddress (which spends from the wallet). Run under -race
+// -count=10 to surface ordering bugs.
+func TestRPC_Concurrent_WarpAndSend(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("failed to create regtest: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("failed to start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(minerWallet); err != nil {
+		t.Fatalf("ensure wallet: %v", err)
+	}
+	defer rt.UnloadWallet(minerWallet)
+
+	minerAddr, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("generate miner addr: %v", err)
+	}
+	if err := rt.Warp(150, minerAddr); err != nil {
+		t.Fatalf("warp to fund: %v", err)
+	}
+
+	recipient, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("generate recipient addr: %v", err)
+	}
+
+	const iterations = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, iterations*2)
+
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if err := rt.Warp(1, minerAddr); err != nil {
+				errs <- fmt.Errorf("warp %d: %w", i, err)
+				return
+			}
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			if _, err := rt.SendToAddress(recipient, 100_000); err != nil {
+				errs <- fmt.Errorf("send %d: %w", i, err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Errorf("concurrent op failed: %v", err)
+	}
 }

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -336,6 +336,105 @@ func Test_IsRunning_AfterCleanup(t *testing.T) {
 	}
 }
 
+// Test_RPCMethods_BeforeStart pins the contract that all RPC-issuing methods
+// return errNotConnected when called before Start() (or after Stop() has
+// cleared the client). No bitcoind required.
+func Test_RPCMethods_BeforeStart(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("failed to create regtest: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Cleanup() })
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{"GetBlockCount", func() error { _, err := rt.GetBlockCount(); return err }},
+		{"HealthCheck", func() error { return rt.HealthCheck() }},
+		{"GetWalletInformation", func() error { _, err := rt.GetWalletInformation(); return err }},
+		{"CreateWallet", func() error { _, err := rt.CreateWallet("w"); return err }},
+		{"LoadWallet", func() error { _, err := rt.LoadWallet("w"); return err }},
+		{"UnloadWallet", func() error { return rt.UnloadWallet("w") }},
+		{"GenerateBech32", func() error { _, err := rt.GenerateBech32("l"); return err }},
+		{"GenerateBech32m", func() error { _, err := rt.GenerateBech32m("l"); return err }},
+		{"ScanTxOutSetForAddress", func() error {
+			_, err := rt.ScanTxOutSetForAddress("bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl")
+			return err
+		}},
+		{"Warp", func() error {
+			return rt.Warp(1, "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl")
+		}},
+	}
+	for _, c := range checks {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.call(); !errors.Is(err, errNotConnected) {
+				t.Errorf("expected errNotConnected, got %v", err)
+			}
+		})
+	}
+}
+
+// Test_StartContext_PreCancelled verifies that StartContext surfaces a
+// pre-cancelled context's error rather than spawning bitcoind.
+func Test_StartContext_PreCancelled(t *testing.T) {
+	rt, err := New(&Config{
+		Host:    "127.0.0.1:19400",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: "./bitcoind_regtest_startcancel",
+	})
+	if err != nil {
+		t.Fatalf("failed to create regtest: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Stop(); _ = rt.Cleanup() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := rt.StartContext(ctx); err == nil {
+		t.Fatal("expected error from cancelled StartContext, got nil")
+	} else if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected ctx.Canceled in error chain, got %v", err)
+	}
+}
+
+// Test_RestartCycle exercises Start → Stop → Start. After the second Start
+// the live client should once again work.
+func Test_RestartCycle(t *testing.T) {
+	rt, err := New(&Config{
+		Host:    "127.0.0.1:19500",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: "./bitcoind_regtest_restart",
+	})
+	if err != nil {
+		t.Fatalf("failed to create regtest: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Stop(); _ = rt.Cleanup() })
+
+	if err := rt.Start(); err != nil {
+		t.Fatalf("first start: %v", err)
+	}
+	if err := rt.HealthCheck(); err != nil {
+		t.Fatalf("health check after first start: %v", err)
+	}
+
+	if err := rt.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if err := rt.HealthCheck(); !errors.Is(err, errNotConnected) {
+		t.Errorf("expected errNotConnected after Stop, got %v", err)
+	}
+
+	if err := rt.Start(); err != nil {
+		t.Fatalf("second start: %v", err)
+	}
+	if err := rt.HealthCheck(); err != nil {
+		t.Fatalf("health check after restart: %v", err)
+	}
+}
+
 // Test_Context_Cancellation verifies that *Context variants surface context
 // errors when the supplied context is already cancelled.
 func Test_Context_Cancellation(t *testing.T) {


### PR DESCRIPTION
Closes #39.

Phase 1.5 of the improvement roadmap. Adds the test coverage tracked when Phases 1.1–1.4 landed.

## New tests

| Test | Needs bitcoind? | What it covers |
|---|---|---|
| \`TestRPC_Warp_ValidationErrors\` | no | Early-return guards in \`WarpContext\` (\`blocks=0\`, \`blocks=-1\`, \`miner=\"\"\`) |
| \`TestRPC_SendToAddress_ValidationErrors\` | no | \`sats<=0\`, empty / malformed address |
| \`TestRPC_Concurrent_WarpAndSend\` | yes | Two goroutines × 20 iterations, Warping vs SendToAddress'ing the same wallet. Stresses dual-mutex pattern |
| \`Test_RPCMethods_BeforeStart\` | no | 10 RPC methods return \`errNotConnected\` before \`Start()\` |
| \`Test_StartContext_PreCancelled\` | no | Cancelled ctx surfaces \`context.Canceled\` rather than launching bitcoind |
| \`Test_RestartCycle\` | yes | \`Start → Stop → Start\` round-trip; \`HealthCheck\` returns errNotConnected after Stop, succeeds after restart |

## Coverage

| Stage | Coverage |
|---|---:|
| Before | 74.4% |
| After  | **81.1%** (+6.7pp) |

## Test plan

- [x] \`go build ./... && go vet ./...\` clean
- [x] Full suite green: \`ulimit -n 4096 && go test -race -timeout 300s -count 1 .\` (~77s)
- [x] Concurrency stress green 10×: \`go test -run TestRPC_Concurrent_WarpAndSend -race -count 10 -timeout 600s .\` (~49s)
- [x] 70% coverage gate still met (now 81.1%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)