### PR TITLE
Add .golangci.yml and tighten make lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,57 @@
+version: "2"
+
+run:
+  timeout: 5m
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+    - gocyclo
+    - misspell
+    - revive
+    - unparam
+    - prealloc
+
+  settings:
+    gocyclo:
+      min-complexity: 15
+    revive:
+      rules:
+        - name: var-naming
+        - name: exported
+        - name: error-return
+        - name: error-strings
+        - name: receiver-naming
+        - name: indent-error-flow
+        - name: unreachable-code
+    gosec:
+      excludes:
+        # Already considered in .gosec.json; G104 (errors not checked) is
+        # better caught by errcheck, and G304 (file inclusion) flags every
+        # os.WriteFile in this package which uses constant paths.
+        - G104
+        - G304
+        - G204 # exec.Command with variable arg — bash + script path is intentional
+
+  exclusions:
+    rules:
+      # Test files intentionally ignore some errors (Stop, Cleanup, Shutdown
+      # in t.Cleanup, etc.) and use higher cyclomatic complexity for
+      # table-driven setups.
+      - path: _test\.go$
+        linters:
+          - errcheck
+          - gocyclo
+          - gosec
+          - unparam
+
+formatters:
+  enable:
+    - gofmt
+    - goimports

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,8 @@ verify:
 ## install-tools: Install development tools
 install-tools:
 	@echo "Installing required development tools..."
-	@echo "Installing golangci-lint..."
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@echo "Installing golangci-lint v2..."
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@echo ""
 	@echo "Required tools installed!"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -164,10 +164,13 @@ verify:
 	$(GO) mod verify
 
 ## install-tools: Install development tools
+# Uses the official install.sh to grab a precompiled golangci-lint binary —
+# avoids requiring Go >= 1.25 just to build the linter from source.
+GOLANGCI_LINT_VERSION ?= v2.11.4
 install-tools:
 	@echo "Installing required development tools..."
-	@echo "Installing golangci-lint v2..."
-	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION)..."
+	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $$(go env GOPATH)/bin $(GOLANGCI_LINT_VERSION)
 	@echo ""
 	@echo "Required tools installed!"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,11 @@ vet:
 	@echo "Running go vet..."
 	$(GOVET) ./...
 
-## lint: Run golangci-lint (lenient mode for development)
+## lint: Run golangci-lint using .golangci.yml
 lint:
 	@echo "Running golangci-lint..."
 	@if command -v golangci-lint >/dev/null 2>&1; then \
-		golangci-lint run --disable=errcheck,unused ./... || true; \
+		golangci-lint run ./...; \
 	else \
 		echo "golangci-lint not installed. Run 'make install-tools' to install it."; \
 		exit 1; \

--- a/regtest.go
+++ b/regtest.go
@@ -400,10 +400,14 @@ func (r *Regtest) initialize() error {
 	}
 	r.scriptTmpDir = tmpDir
 
-	// Write the embedded script to the temp directory
+	// Write the embedded script to the temp directory. The script is invoked
+	// as `bash <scriptPath> ...` so it doesn't need the executable bit; 0600
+	// (owner read/write only) is sufficient and avoids gosec G306.
 	scriptPath := filepath.Join(tmpDir, "bitcoind_manager.sh")
-	if err := os.WriteFile(scriptPath, []byte(bitcoindManagerScript), 0755); err != nil {
-		os.RemoveAll(tmpDir) // Clean up on error
+	if err := os.WriteFile(scriptPath, []byte(bitcoindManagerScript), 0600); err != nil {
+		if rmErr := os.RemoveAll(tmpDir); rmErr != nil {
+			return fmt.Errorf("failed to write bitcoind manager script (%w) and failed to clean up temp dir (%w)", err, rmErr)
+		}
 		return fmt.Errorf("failed to write bitcoind manager script: %w", err)
 	}
 	r.scriptPath = scriptPath


### PR DESCRIPTION
Closes #43.

Phase 3.1 of the improvement roadmap.

## Config (\`.golangci.yml\`, golangci-lint v2 schema)

| Linter | Notes |
|---|---|
| \`errcheck\`, \`govet\`, \`ineffassign\`, \`staticcheck\`, \`unused\` | Standard correctness |
| \`gosec\` | Excludes G104 (covered by errcheck), G304 (constant paths), G204 (intentional \`bash + script-path\` exec) |
| \`gocyclo\` | Threshold 15 |
| \`misspell\`, \`revive\`, \`unparam\`, \`prealloc\` | Style + cleanup |
| \`gofmt\`, \`goimports\` | Under \`formatters\` block |

Test files exempted from \`errcheck\`/\`gocyclo\`/\`gosec\`/\`unparam\` — test code legitimately ignores some errors and uses higher complexity for table-driven setups.

## Surfaced issues (both fixed in this PR)

| Location | Linter | Fix |
|---|---|---|
| \`regtest.go\` initialize: \`os.RemoveAll(tmpDir)\` | errcheck | Now wraps both errors in the failure path |
| \`regtest.go\` initialize: \`os.WriteFile(..., 0755)\` | gosec G306 | Script is invoked as \`bash <path>\` — exec bit isn't needed. Tightened to \`0600\` |

## Makefile

- \`make lint\` drops \`--disable=errcheck,unused\` and the trailing \`|| true\` swallow. Lint failures now fail the target.

## Test plan

- [x] \`golangci-lint run ./...\` → 0 issues
- [x] \`make lint\` exits 0
- [x] \`go test -timeout 180s ./...\` → ok (~77s)
- [x] \`go build ./... && go vet ./...\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)