### PR TITLE
Add minimal issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report
+about: Something isn't behaving the way the docs / API suggests it should
+title: ""
+labels: bug
+---
+
+## What happened
+
+<!-- One or two sentences describing the actual behavior. -->
+
+## Expected behavior
+
+<!-- What did you expect instead? -->
+
+## Reproduction
+
+<!-- Minimal Go snippet (or steps) that triggers the bug. The shorter the better. -->
+
+```go
+
+```
+
+## Environment
+
+- go-regtest version / commit:
+- `go version`:
+- `bitcoind --version`:
+- OS:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/neverDefined/go-regtest/security/advisories/new
+    about: Report a security issue privately via GitHub Security Advisories.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a new capability or API change
+title: ""
+labels: enhancement
+---
+
+## What you want
+
+<!-- The new behavior in a sentence. -->
+
+## Why
+
+<!-- The use case or problem this would solve. Concrete examples help. -->
+
+## Sketch (optional)
+
+<!-- API shape, snippet, or rough proposal. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!--
+Closes # <!-- issue number, if any -->
+
+Keep PRs focused on one concern. If you find yourself writing "and also...", split it.
+-->
+
+## Summary
+
+<!-- What does this change and why. One paragraph. -->
+
+## Test plan
+
+- [ ] `make check-all` passes locally
+- [ ] New behavior is covered by tests, or no behavior change


### PR DESCRIPTION
Closes #41.

Phase 2.2 of the improvement roadmap. Kept lean per your no-heavy-governance preference — these are prompts for clarity when an issue or PR does come in, not paperwork.

## What's added

- \`.github/ISSUE_TEMPLATE/bug_report.md\` — repro snippet + env (go / bitcoind / OS versions)
- \`.github/ISSUE_TEMPLATE/feature_request.md\` — what / why / optional sketch
- \`.github/ISSUE_TEMPLATE/config.yml\` — leaves blank issues enabled; routes security reports to the GitHub Security Advisories form
- \`.github/PULL_REQUEST_TEMPLATE.md\` — Closes # / summary / test-plan checklist

## Test plan

- [ ] Open a throwaway issue with each template to confirm rendering
- [ ] Open a throwaway PR to confirm the PR template renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)