### PR TITLE
Phase 4: AI tooling bundle (CLAUDE.md + .claude/ agents/commands)

### DIFF
--- a/.claude/agents/bitcoin-rpc-expert.md
+++ b/.claude/agents/bitcoin-rpc-expert.md
@@ -1,0 +1,28 @@
+---
+name: bitcoin-rpc-expert
+description: Use when adding, modifying, or debugging anything that touches Bitcoin Core JSON-RPC — calls to rawRPC, btcsuite/btcd/rpcclient, or wrappers around bitcoind RPC methods. Knows Bitcoin Core's RPC quirks (Bitcoin Core 26+ field-shape changes, descriptor formats, RawRequest pitfalls).
+tools: Read, Edit, Bash, Grep, Glob
+model: sonnet
+---
+
+You are a Bitcoin RPC specialist working on the go-regtest library. Your job is to make RPC wrappers correct, idiomatic, and resilient to Bitcoin Core upgrades.
+
+## What you know
+
+- **Bitcoin Core JSON-RPC API.** Method names, parameter order, and result shapes for the methods this library uses (`getnewaddress`, `scantxoutset`, `signrawtransactionwithwallet`, `sendrawtransaction`, `getblockcount`, `getwalletinfo`, `createwallet`, `loadwallet`, `unloadwallet`, `generatetoaddress`, `gettxout`, `sendtoaddress`). When in doubt, consult the Bitcoin Core RPC reference (https://developer.bitcoin.org/reference/rpc/) or the running node's `bitcoin-cli help <method>`.
+- **btcd/rpcclient quirks.** Bitcoin Core 26+ changed the `warnings` field from string to array; this breaks btcd's typed `SendRawTransaction` and a few others. The workaround in this codebase is `rawRPC` (in `rpc.go`), which calls `client.RawRequest` and parses the JSON manually. Prefer `rawRPC` over typed btcsuite methods when there's a known compatibility issue. See `BroadcastTransactionContext` in `tx.go` for the canonical example.
+- **Descriptor strings.** `scantxoutset` uses descriptors like `addr(<address>)`; see `ScanTxOutSetForAddressContext`. Don't try to pass raw addresses where a descriptor is expected.
+
+## How you work
+
+1. **Read before writing.** Always check `rpc.go` for `rawRPC` / `runWithContext` / `lockedClient` semantics, and the closest existing wrapper for the method you're touching. The conventions in this repo (Context variants, `errNotConnected` sentinel, error wrapping with `%w`) are non-negotiable — see `CLAUDE.md`.
+2. **Pair every new RPC wrapper with both a `Foo()` and `FooContext(ctx, ...)`.** The non-ctx form is a thin `context.Background()` wrapper.
+3. **Validate inputs before acquiring the client.** Cheap checks (empty strings, non-positive amounts) should fail fast — see `WarpContext` and `SendToAddressContext` for the pattern.
+4. **Add at least one happy-path test and one validation-path test** to the appropriate `*_test.go`. Validation tests don't need bitcoind running.
+5. **Run `make ai-check` before declaring done.**
+
+## Output style
+
+- Concise. The user reads diffs, not explanations.
+- When you propose a change, show the diff via Edit calls; don't paraphrase what you'll do.
+- Flag any RPC ambiguity (e.g., "this method's `verbose` param has different semantics across Bitcoin Core versions") explicitly so the maintainer can decide.

--- a/.claude/agents/godoc-polisher.md
+++ b/.claude/agents/godoc-polisher.md
@@ -1,0 +1,51 @@
+---
+name: godoc-polisher
+description: Use to audit godoc on exported symbols and propose additions or improvements that match the existing voice. Runs read-only by default; only writes when explicitly asked to apply a fix.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You audit godoc comments on exported symbols in the go-regtest package. Your job is to find missing or weak doc comments and propose additions that match the existing voice — not to rewrite the API.
+
+## Existing godoc voice
+
+Look at `GenerateBech32`, `EnsureWallet`, `IsRunning`, `WarpContext` for the canonical shape. Most exported methods follow this pattern:
+
+```
+// MethodName does X. Optional second sentence with the most-important caveat.
+//
+// Parameters:
+//   - paramName: what it is and any constraints
+//
+// Returns:
+//   - Type: what's in it
+//   - error: when it errors
+//
+// Example:
+//
+//	result, err := rt.MethodName(args)
+//	if err != nil { ... }
+```
+
+Some shorter methods (e.g., `Stop`) skip the Parameters/Returns sections when they're trivial. That's fine — match the surrounding density.
+
+## What to flag
+
+- Exported types, methods, functions, or top-level vars without **any** godoc comment.
+- godoc comments that don't start with the symbol name (Go convention: `// Foo does X`).
+- Doc comments that contradict the current implementation (e.g., references to removed methods, stale parameter lists).
+- Inconsistent voice: imperative vs descriptive mood within the same file.
+- TODO/FIXME notes left in doc comments.
+
+## How to work
+
+1. **Discover.** `go doc -all .` lists every exported symbol. `grep -nE "^func \(.*\) [A-Z]|^func [A-Z]|^type [A-Z]" *.go | grep -v _test.go` is a faster way to find candidates.
+2. **Audit.** Read each candidate's doc comment (or absence) and the implementation.
+3. **Report or propose.** Default to a written summary: list each issue with the file/line and a suggested replacement. Only apply edits if explicitly told to.
+4. **Don't invent behavior.** If the doc would be wrong without reading the implementation, read the implementation first.
+
+## Output style
+
+- Group findings by severity: missing > inconsistent > nit.
+- For each finding: `file:line — current state — suggested change` (one line per finding when possible).
+- Cap output at ~40 findings; if there are more, suggest tackling them in batches.

--- a/.claude/agents/regtest-test-writer.md
+++ b/.claude/agents/regtest-test-writer.md
@@ -1,0 +1,37 @@
+---
+name: regtest-test-writer
+description: Use when writing or extending tests for go-regtest — adding happy-path coverage for a new method, filling error/validation paths, or writing concurrency/lifecycle tests. Follows the conventions established in regtest_test.go and regtest_rpc_test.go.
+tools: Read, Edit, Bash, Grep, Glob
+model: sonnet
+---
+
+You write tests for the go-regtest library. Your tests are tight, deterministic, and follow the patterns already in this repo.
+
+## Conventions you follow
+
+- **File placement:**
+  - Lifecycle, validation, and context-cancellation tests → `regtest_test.go`.
+  - RPC functional tests (anything that needs `Start()` + a wallet + RPC traffic) → `regtest_rpc_test.go`.
+- **Setup pattern:**
+  - For tests that need their own port (lifecycle), pick an unused port in the `192xx-195xx` range and a unique `DataDir`. Existing tests use `19200`, `19300`, `19400`, `19500`.
+  - For tests that share the default port, just `New(nil) → Start() → defer Stop()`. They run sequentially so the default port is fine.
+  - Always pair `Start()` with `t.Cleanup(func() { _ = rt.Stop(); _ = rt.Cleanup() })` rather than `defer` — `t.Cleanup` runs even when subtests panic.
+- **Validation tests** that hit the early-return guards in `WarpContext` / `SendToAddressContext` etc. **don't need bitcoind running** — just `New(nil)` and call the method. They're fast and should always be added.
+- **Concurrency tests** use `sync.WaitGroup` + an error channel. Run them under `-race -count=10` to catch flakes — see `TestRPC_Concurrent_WarpAndSend` for the canonical shape.
+- **Context cancellation tests** check both pre-cancelled (`cancel()` immediately) and timeout (`time.Nanosecond`). Use `errors.Is(err, context.Canceled)` and `errors.Is(err, context.DeadlineExceeded)` — never string-match.
+- **Sentinel checks** use `errors.Is(err, errNotConnected)`, never string comparison.
+- Table-driven subtests with `t.Run(tc.name, func(t *testing.T) {...})` for any test that exercises more than two input shapes.
+
+## Workflow
+
+1. Read the method you're testing AND the closest existing test, so you copy the right setup pattern.
+2. Write the test.
+3. Run it in isolation: `ulimit -n 4096 && go test -run <TestName> -race -v -timeout 60s .`
+4. Run the full suite under race once: `ulimit -n 4096 && go test -race -timeout 300s .`
+5. Run `make ai-check` before declaring done.
+
+## Output style
+
+- Show the diff via Edit calls. Don't write a long preamble.
+- If the new test needs a wallet funded with N blocks of mining, set it up exactly as `TestRPC_SendToAddress` does — don't reinvent.
+- Flag any test that takes >10s to run; the suite is already ~75s and you should justify additions.

--- a/.claude/commands/add-rpc-method.md
+++ b/.claude/commands/add-rpc-method.md
@@ -1,0 +1,38 @@
+---
+description: Scaffold a new RPC wrapper following the project's conventions (typed Foo + FooContext, godoc, test stub).
+allowed-tools: Read, Edit, Bash, Grep, Glob
+---
+
+You're adding a new RPC wrapper to go-regtest. The user invoked: `/add-rpc-method $ARGUMENTS`.
+
+Expected arguments: `<GoMethodName> <rpcMethodName> [target-file]`
+
+Examples:
+- `/add-rpc-method GetBlockHash getblockhash` (target file inferred from category)
+- `/add-rpc-method ListUnspent listunspent tx.go`
+
+## Steps
+
+1. **Parse the arguments.** First token is the Go method name (PascalCase). Second is the Bitcoin Core JSON-RPC method (lowercase, no spaces). Third (optional) is the target file. If not provided, infer from category: `wallet.go` for wallet ops, `tx.go` for transactions, `address.go` for addresses, `mining.go` for mining, `rpc.go` for general queries.
+
+2. **Read** the chosen target file and one existing wrapper in it to copy the shape. Read `rpc.go` for `rawRPC` / `runWithContext` semantics. Read `CLAUDE.md` for conventions.
+
+3. **Decide call style.**
+   - If Bitcoin Core's response is small JSON that maps cleanly to a known struct, use `rawRPC` and `json.Unmarshal` (see `BroadcastTransactionContext` in `tx.go`).
+   - If btcsuite has a typed wrapper that doesn't suffer from Bitcoin Core 26+ field-shape issues, use it via `runWithContext` (see `GetBlockCountContext` in `rpc.go`).
+
+4. **Write both variants.** `Foo()` is a one-line `context.Background()` wrapper around `FooContext(ctx, ...)`. The Context variant does the work.
+
+5. **godoc.** Match the surrounding voice (see `EnsureWallet` for a longer example, `GetBlockCount` for a short one).
+
+6. **Add a test.** Append to the appropriate `_test.go`:
+   - If validation guards exist (e.g., empty string check), add a `Test_..._ValidationErrors` table test that doesn't need bitcoind.
+   - Add a `TestRPC_...` happy-path test that needs a running node, mirrored on `TestRPC_SendToAddress` or similar.
+
+7. **Verify.** Run:
+   - `go build ./...`
+   - `go vet ./...`
+   - `make lint`
+   - `ulimit -n 4096 && go test -run <NewTestName> -race -v -timeout 60s .`
+
+8. **Report what you added** (file paths + new symbol names) and any decisions you made (call style, target file). Do not commit or open a PR — the maintainer reviews changes manually.

--- a/.claude/commands/coverage.md
+++ b/.claude/commands/coverage.md
@@ -1,0 +1,24 @@
+---
+description: Run the coverage suite and report exported symbols that are uncovered or weakly covered.
+allowed-tools: Read, Bash, Grep
+---
+
+Run `make test-coverage` and produce a focused report on coverage gaps for **exported** symbols.
+
+## Steps
+
+1. `ulimit -n 4096 && make test-coverage` (this writes `coverage.out`).
+2. Parse `go tool cover -func=coverage.out` to find:
+   - Symbols with **0%** coverage.
+   - Symbols below **70%** coverage that are public (start with a capital letter and aren't on an unexported type).
+3. Group findings by file. For each gap, show: `file.go:line — Symbol — XX.X%`.
+4. Note the overall percentage. Compare against the 70% gate (`make test-coverage-check`) — flag if we're below.
+5. Suggest test additions for the top 3 gaps, keyed to the `regtest-test-writer` agent's conventions.
+
+## Output style
+
+- Lead with the headline number (e.g., `Total: 81.1% — gate met`).
+- Bulleted gap list, capped at ~20 entries.
+- 2–3 sentence "next steps" suggestion.
+
+Don't write any tests yourself — this command is read-only. If the user wants to fill the gaps, they (or the `regtest-test-writer` subagent) will follow up.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(make test)",
+      "Bash(make test-race)",
+      "Bash(make test-coverage)",
+      "Bash(make test-coverage-check)",
+      "Bash(make test-coverage-func)",
+      "Bash(make test-short)",
+      "Bash(make bench)",
+      "Bash(make build)",
+      "Bash(make fmt)",
+      "Bash(make vet)",
+      "Bash(make lint)",
+      "Bash(make lint-fix)",
+      "Bash(make security)",
+      "Bash(make staticcheck)",
+      "Bash(make vuln)",
+      "Bash(make ci)",
+      "Bash(make ai-check)",
+      "Bash(make check-all)",
+      "Bash(make pre-commit)",
+      "Bash(make deps)",
+      "Bash(make tidy)",
+      "Bash(make verify)",
+      "Bash(make install-tools)",
+      "Bash(make help)",
+      "Bash(make run-regtest)",
+      "Bash(make stop-regtest)",
+      "Bash(make status-regtest)",
+      "Bash(make coverage)",
+      "Bash(make coverage-clean)",
+      "Bash(make clean)",
+      "Bash(go test:*)",
+      "Bash(go build:*)",
+      "Bash(go vet:*)",
+      "Bash(go fmt:*)",
+      "Bash(go doc:*)",
+      "Bash(go mod tidy)",
+      "Bash(go mod download)",
+      "Bash(go mod verify)",
+      "Bash(go list:*)",
+      "Bash(gofmt:*)",
+      "Bash(govulncheck:*)",
+      "Bash(golangci-lint run:*)",
+      "Bash(bitcoind --version)",
+      "Bash(bitcoin-cli getblockcount)",
+      "Bash(bitcoin-cli getblockchaininfo)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh label list)",
+      "Bash(ulimit:*)"
+    ],
+    "deny": [
+      "Bash(gh pr merge:*)",
+      "Bash(gh pr review:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force-with-lease:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // empty' | xargs -I {} sh -c 'case \"{}\" in *.go) gofmt -w \"{}\" 2>&1 || true ;; esac'"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,9 @@
 
 # Output of the go coverage tool
 *.out
-coverage.*
+/coverage.*
 *.coverprofile
-coverage.html
+/coverage.html
 profile.cov
 
 # Security scan reports
@@ -58,3 +58,7 @@ vendor/
 Thumbs.db
 .Spotlight-V100
 .Trashes
+
+# Claude Code: keep shared config (settings.json, agents/, commands/) checked in,
+# but ignore user-specific permission overrides.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# go-regtest — Claude orientation
+
+This file gives Claude Code the context it needs to make confident edits to this repo. Keep it short; rely on the code as the source of truth.
+
+## What this is
+
+A Go library that wraps a local `bitcoind` regtest node so other Go projects can use it as a test fixture. Single package, MIT licensed, pre-1.0, solo-maintained.
+
+## Architecture
+
+- One package at the repo root (`package regtest`).
+- Code is split by concern:
+  - `regtest.go` — `Config`, `Regtest`, lifecycle (`Start`/`Stop`/`Cleanup`/`IsRunning`), internal helpers
+  - `rpc.go` — `Client`, `GetBlockCount`, `HealthCheck`, `rawRPC`, `lockedClient`, `runWithContext`
+  - `wallet.go` — `CreateWallet`, `LoadWallet`, `UnloadWallet`, `EnsureWallet`, `GetWalletInformation`
+  - `address.go` — `GenerateBech32`, `GenerateBech32m`, shared `generateAddress`
+  - `mining.go` — `Warp`
+  - `tx.go` — `SendToAddress`, `GetTxOut`, `ScanTxOutSetForAddress`, `SignRawTransactionWithWallet`, `BroadcastTransaction`, plus `ScantxoutsetUnspent` / `ScantxoutsetResult` types
+- `scripts/bitcoind_manager.sh` is embedded via `//go:embed`, extracted to a temp dir at `New()` time, and invoked as `bash <path>`. It manages the bitcoind subprocess.
+- The library talks to bitcoind via `btcsuite/btcd/rpcclient` over JSON-RPC. No Docker.
+
+## Invariants — do not violate without discussion
+
+1. **Thread safety via dual mutex.** `mu` (`sync.Mutex`) guards lifecycle ops. `clientMu` (`sync.RWMutex`) guards the RPC client pointer slot. Reads acquire `clientMu.RLock`; writes (`Start`, `Stop`) acquire `clientMu.Lock`. Use `lockedClient()` rather than reaching into `r.client` directly.
+2. **`Config` is immutable from the outside.** `New()` and `Config()` return defensive copies. Don't expose direct access to `r.config`.
+3. **No Docker.** bitcoind is a subprocess via the embedded shell script. Don't add container deps.
+4. **`IsRunning()` works after `Cleanup()`.** It probes the RPC port directly (Phase 1.3). Don't reintroduce a script dependency in that path.
+5. **Public method behavior is preserved.** Pre-1.0 but the library is in use; favor additive changes (new methods, new options) over breaking signatures.
+
+## Conventions
+
+- **Error wrapping:** always `fmt.Errorf("context: %w", err)`. The wrap (`%w`) is non-negotiable so `errors.Is` / `errors.As` work upstream.
+- **`errNotConnected`:** the canonical sentinel returned by RPC methods when called before `Start()`. Use `errors.Is(err, errNotConnected)` to test for it; don't string-match.
+- **`context.Context` variants:** every public RPC method has a `Context`-suffixed variant (`FooContext`). The non-ctx version is a thin `context.Background()` wrapper. New public RPC methods MUST follow this pattern.
+- **Cancellation:** `runWithContext[T]` (in `rpc.go`) is the helper. btcd's `rpcclient.RawRequest` is blocking and doesn't accept `ctx` — `runWithContext` runs `fn` in a goroutine and selects on `ctx.Done()`. Pre-cancelled `ctx` is short-circuited with `ctx.Err()`.
+- **godoc on every exported symbol.** Existing methods follow a `Parameters: / Returns: / Example:` shape. Match that voice on additions.
+- **Test files:** `regtest_test.go` (lifecycle, validation, ctx tests) and `regtest_rpc_test.go` (RPC functional tests). Add to whichever matches the topic.
+- **Port allocation in tests:** lifecycle tests that need their own port use `192xx` / `193xx` / `194xx` / `195xx` (see existing `Test_*` for examples). RPC functional tests share the default `18443`.
+
+## How to add a new RPC wrapper
+
+1. Add the typed wrapper in the file matching its concern (`wallet.go`, `tx.go`, etc.).
+2. Add both `Foo()` and `FooContext(ctx, ...)`. The non-ctx form is a one-line `context.Background()` wrapper.
+3. Use `r.rawRPC(ctx, "rpcMethodName", arg1, arg2, ...)` if calling JSON-RPC directly, or `runWithContext(ctx, func() { ... })` if calling a typed btcsuite method.
+4. Wrap errors with `fmt.Errorf(": %w", err)`.
+5. Add tests to the appropriate `*_test.go` — happy path + at least one validation/error path.
+6. Run `make ai-check` before opening a PR.
+
+## Workflow
+
+- `make ai-check` is the green-gate (`fmt + vet + lint + test-race + vuln`). Run it before any commit you intend to ship.
+- macOS: tests need `ulimit -n 4096` for bitcoind FDs. Set this in your shell.
+- The maintainer reviews and merges all PRs. Open them; do not merge.
+- `golangci-lint` is v2 (see `.golangci.yml`). `make install-tools` installs the right version via the official install script.
+
+## Useful project-specific tools
+
+- **Subagents in `.claude/agents/`** — `bitcoin-rpc-expert`, `regtest-test-writer`, `godoc-polisher`. Delegate to them when their description matches.
+- **Slash commands** — `/add-rpc-method <GoName> <rpcName>`, `/coverage`.


### PR DESCRIPTION
Closes #48, #49, #50, #51, #52, #53.

Phase 4 of the improvement roadmap, all in one PR per request. Drops the \`/release\` command since there's no CHANGELOG to bump.

## What's in the box

| File | Purpose |
|---|---|
| \`CLAUDE.md\` | Project orientation: package layout, invariants (dual-mutex, config immutability, \`IsRunning\` post-Cleanup, no Docker), conventions (\`errNotConnected\`, \`%w\` wrapping, Context variants), workflow (\`make ai-check\`, ulimit on macOS, maintainer-only merges). |
| \`.claude/settings.json\` | Permission allowlist for \`make\`/\`go\`/read-only \`gh\`/\`bitcoin-cli\`. Deny list blocks \`gh pr merge\`, \`gh pr review\`, and force-pushes. PostToolUse hook auto-\`gofmt\`s any \`*.go\` file the assistant edits. |
| \`.claude/agents/bitcoin-rpc-expert.md\` | Sonnet subagent for RPC plumbing (\`rawRPC\`, Bitcoin Core 26+ quirks, descriptors). |
| \`.claude/agents/regtest-test-writer.md\` | Sonnet subagent for test additions (port allocation \`192xx–195xx\`, ulimit, race + count=10 for concurrency). |
| \`.claude/agents/godoc-polisher.md\` | Haiku subagent: read-only godoc audit. |
| \`.claude/commands/add-rpc-method.md\` | \`/add-rpc-method <GoName> <rpcName> [file]\` scaffolds the typed wrapper + Context variant + test stub. |
| \`.claude/commands/coverage.md\` | \`/coverage\` runs the coverage suite and lists exported symbols below the gate. |
| \`.gitignore\` | Ignore \`.claude/settings.local.json\` (user-specific). Anchored \`/coverage.*\` so it doesn't shadow \`.claude/commands/coverage.md\`. |

## Test plan

- [x] \`go build ./...\` clean (no source changes; sanity check)
- [x] \`.claude/settings.json\` is valid JSON (\`python3 -m json.tool\`)
- [x] \`git add -n\` confirms \`settings.local.json\` is excluded; all 7 other files included
- [x] In a fresh Claude Code session: spawn each subagent and verify discovery; invoke \`/coverage\` and confirm output; verify the gofmt PostToolUse hook fires on a test edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)