### PR TITLE
Add golangci-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,13 @@ repos:
         files: \.go$
         pass_filenames: false
 
+      - id: golangci-lint
+        name: golangci-lint
+        entry: make lint
+        language: system
+        files: \.go$
+        pass_filenames: false
+
       - id: go-test
         name: go test
         entry: make test


### PR DESCRIPTION
Closes #47.

Phase 3.5 of the improvement roadmap.

Adds a \`golangci-lint\` hook to \`.pre-commit-config.yaml\` between \`go-vet\` and \`go-test\`. Delegates to \`make lint\`, which runs golangci-lint with \`.golangci.yml\` against the full package. Runs on every commit (default stage) for any \`*.go\` change.

Kept as a local \`language: system\` hook rather than the golangci upstream mirror so the exact version installed by \`make install-tools\` is the one that fires — consistent with the existing \`go-fmt\` and \`go-vet\` hooks.

## Test plan

- [x] \`.pre-commit-config.yaml\` parses cleanly
- [x] \`make lint\` still clean (0 issues)
- [x] Local: \`pre-commit install && pre-commit run golangci-lint --all-files\` succeeds (requires \`pip install pre-commit\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)