### PR TITLE
Add goreleaser + release workflow + make release-dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write   # publish GitHub releases
+
+jobs:
+  release:
+    name: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # goreleaser needs full history for changelog
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.23'
+          cache: true
+
+      - name: Install Bitcoin Core
+        run: |
+          sudo snap install bitcoin-core
+          sudo ln -sf /snap/bitcoin-core/current/bin/bitcoind /usr/local/bin/bitcoind
+          sudo ln -sf /snap/bitcoin-core/current/bin/bitcoin-cli /usr/local/bin/bitcoin-cli
+
+      - name: Install development tools
+        run: make install-tools
+
+      - name: Run full test suite
+        # Don't release a tag whose code doesn't pass tests.
+        run: |
+          ulimit -n 4096
+          make ci
+
+      - name: Run goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,59 @@
+# goreleaser config for go-regtest.
+# This is a library, not a binary distribution — releases publish a tagged
+# source archive + checksums + a GitHub Release with auto-generated notes.
+# Run `make release-dry-run` to verify locally without publishing.
+version: 2
+
+project_name: go-regtest
+
+before:
+  hooks:
+    - go mod tidy
+
+# No binaries to build — this is a library consumed via `go get`.
+builds:
+  - skip: true
+
+# Bundle the source as a tarball for the GitHub Release.
+source:
+  enabled: true
+  name_template: "{{ .ProjectName }}-{{ .Version }}-source"
+
+checksum:
+  name_template: "checksums.txt"
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot-{{ .ShortCommit }}"
+
+# Pull release notes from git history. Filters drop merge commits and
+# noise; everything else surfaces in the GitHub Release body.
+changelog:
+  use: git
+  sort: asc
+  filters:
+    exclude:
+      - "^Merge pull request"
+      - "^Merge branch"
+      - "^docs:"
+      - "^chore:"
+      - "^ci:"
+
+release:
+  github:
+    owner: neverDefined
+    name: go-regtest
+  draft: false
+  # Tags like v0.1.0-rc.1 / v0.1.0-beta.1 will be marked prerelease.
+  prerelease: auto
+  # Emphasize that this is a library; consumers install via `go get`.
+  header: |
+    ## go-regtest {{ .Version }}
+
+    Install:
+
+    ```
+    go get github.com/neverDefined/go-regtest@{{ .Tag }}
+    ```
+  footer: |
+    ---
+    [Full changelog](https://github.com/neverDefined/go-regtest/compare/{{ .PreviousTag }}...{{ .Tag }})

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test test-race test-coverage clean lint lint-fix security fmt vet install-tools deps tidy run-regtest stop-regtest check-all vuln ai-check
+.PHONY: help build test test-race test-coverage clean lint lint-fix security fmt vet install-tools deps tidy run-regtest stop-regtest check-all vuln ai-check release-dry-run
 
 # Default target
 .DEFAULT_GOAL := help
@@ -161,6 +161,15 @@ vuln:
 ai-check: fmt vet lint test-race vuln
 	@echo ""
 	@echo "ai-check passed!"
+
+## release-dry-run: Build a snapshot release locally (no publish)
+release-dry-run:
+	@echo "Running goreleaser snapshot..."
+	@if ! command -v goreleaser >/dev/null 2>&1; then \
+		echo "  goreleaser not found. Install: brew install goreleaser/tap/goreleaser"; \
+		exit 1; \
+	fi
+	@goreleaser release --snapshot --clean
 
 ##@ Dependencies
 


### PR DESCRIPTION
Closes #42 — completes the original improvement roadmap.

Phase 2.3 of the improvement roadmap. Library-flavored release pipeline — no binaries shipped, just a tagged GitHub Release with source archive, checksums, and commit-driven release notes (no \`CHANGELOG.md\` per your preference).

## What's added

| File | Purpose |
|---|---|
| \`.goreleaser.yaml\` | v2 schema. \`builds.skip: true\` (library), source archive enabled, checksums, git-based changelog filtering merge commits + docs/chore/ci prefixes. Release header includes the \`go get\` install line keyed to the tag. |
| \`.github/workflows/release.yml\` | Triggered on \`v*\` tag push. Full history checkout, install Bitcoin Core + dev tools, run \`make ci\` (don't release broken code), then \`goreleaser release --clean\` via \`goreleaser-action@v6\`. \`contents: write\` permission for the publish. |
| \`Makefile\` | New \`make release-dry-run\` runs \`goreleaser release --snapshot --clean\`. Errors with brew install hint if missing. |

## Local verification

\`\`\`
$ goreleaser check
  • 1 configuration file(s) validated

$ make release-dry-run
  • building snapshot... version=0.0.1-snapshot-1f291d1
  • creating source archive  file=dist/go-regtest-0.0.1-snapshot-1f291d1-source.tar.gz
  • calculating checksums
  • release succeeded after 0s

$ ls dist/
  artifacts.json
  checksums.txt
  config.yaml
  go-regtest-0.0.1-snapshot-1f291d1-source.tar.gz   # 39KB
  metadata.json
\`\`\`

## How to release after merge

\`\`\`bash
git checkout main && git pull
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
\`\`\`

That's it — \`release.yml\` fires on the tag push, runs \`make ci\`, and publishes the GitHub Release with notes auto-generated from \`git log\`.

## Test plan

- [x] \`goreleaser check\` passes locally
- [x] \`make release-dry-run\` produces source tarball + checksums
- [x] Existing CI (\`ci.yml\`) stays green on this PR — release.yml only fires on tags so it's not validated until you tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)