### PR TITLE
README: include Cleanup, DefaultConfig, and *Context variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ type Config struct {
 
 ### Methods
 
-**Lifecycle:** `Start()`, `Stop()`, `IsRunning()`
+**Lifecycle:** `Start()`, `Stop()`, `Cleanup()`, `IsRunning()`
 
-**Configuration:** `Config()`, `RPCConfig()`
+**Configuration:** `DefaultConfig()`, `Config()`, `RPCConfig()`
 
 **RPC:** `Client()`, `GetBlockCount()`, `HealthCheck()`
 
@@ -152,6 +152,8 @@ type Config struct {
 **Mining:** `Warp(blocks, address)`
 
 **Transactions:** `SendToAddress(address, sats)`, `GetTxOut(txid, vout, includeMempool)`, `ScanTxOutSetForAddress(address)`, `SignRawTransactionWithWallet(tx)`, `BroadcastTransaction(tx)`
+
+Every RPC-issuing method also has a `*Context` variant (`StartContext`, `GetBlockCountContext`, `WarpContext`, etc.) that accepts a `context.Context` for timeout and cancellation. The non-`Context` form is a thin `context.Background()` wrapper.
 
 See [godoc](https://pkg.go.dev/github.com/neverDefined/go-regtest) for detailed API documentation.
 


### PR DESCRIPTION
Re-opening as a PR after accidentally committing directly to main (reverted in 6b4c722).

The API Reference summary in the README missed three things that exist in the code:

- \`Cleanup()\` — lifecycle, exists since v0.0, was never listed
- \`DefaultConfig()\` — top-level configuration helper
- The family of \`*Context\` variants added in Phase 1.2

Quick Start and Common Operations snippets were already correct — this only touches the summary list (+2 symbols) and adds one line about the Context variant convention.

+4 / -2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)