### PR TITLE
[Phase 5.A.1] Forward Config.ExtraArgs to bitcoind

### DIFF
--- a/regtest.go
+++ b/regtest.go
@@ -216,8 +216,10 @@ func (r *Regtest) StartContext(ctx context.Context) error {
 
 	port := r.extractPort()
 
-	// Pass config parameters to script: start datadir port user pass
-	cmd := exec.CommandContext(ctx, "bash", r.scriptPath, "start", r.config.DataDir, port, r.config.User, r.config.Pass)
+	// Pass config parameters to script: start datadir port user pass [extra-args...].
+	// ExtraArgs are forwarded verbatim to bitcoind by the script (see scripts/bitcoind_manager.sh).
+	scriptArgs := append([]string{r.scriptPath, "start", r.config.DataDir, port, r.config.User, r.config.Pass}, r.config.ExtraArgs...)
+	cmd := exec.CommandContext(ctx, "bash", scriptArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() != nil {

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -2,6 +2,7 @@ package regtest
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"testing"
@@ -469,5 +470,62 @@ func Test_Context_Cancellation(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 		t.Errorf("expected ctx error, got %v", err)
+	}
+}
+
+// Test_ExtraArgs_Forwarded verifies that Config.ExtraArgs are passed through
+// to bitcoind. Sets -debug=mempool and asserts the mempool category is
+// enabled via the `logging` RPC.
+func Test_ExtraArgs_Forwarded(t *testing.T) {
+	rt, err := New(&Config{
+		Host:      "127.0.0.1:19600",
+		User:      "user",
+		Pass:      "pass",
+		DataDir:   "./bitcoind_regtest_extraargs",
+		ExtraArgs: []string{"-debug=mempool"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Stop(); _ = rt.Cleanup() })
+
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	raw, err := rt.rawRPC(ctx, "logging")
+	if err != nil {
+		t.Fatalf("logging RPC: %v", err)
+	}
+	var categories map[string]bool
+	if err := json.Unmarshal(raw, &categories); err != nil {
+		t.Fatalf("unmarshal logging response: %v: %s", err, raw)
+	}
+	if !categories["mempool"] {
+		t.Errorf("expected mempool=true with -debug=mempool, got: %v", categories)
+	}
+}
+
+// Test_ExtraArgs_UnknownFlag verifies that an invalid bitcoind flag passed
+// via Config.ExtraArgs surfaces as a Start error rather than silently
+// succeeding. Pins the contract that ExtraArgs are actually forwarded.
+func Test_ExtraArgs_UnknownFlag(t *testing.T) {
+	rt, err := New(&Config{
+		Host:      "127.0.0.1:19601",
+		User:      "user",
+		Pass:      "pass",
+		DataDir:   "./bitcoind_regtest_extraargs_bad",
+		ExtraArgs: []string{"-this-flag-does-not-exist=1"},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Stop(); _ = rt.Cleanup() })
+
+	if err := rt.Start(); err == nil {
+		t.Fatal("expected Start to fail for unknown flag, got nil")
 	}
 }

--- a/scripts/bitcoind_manager.sh
+++ b/scripts/bitcoind_manager.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 
 # Bitcoin Core daemon management script
-# Usage: ./bitcoind_manager.sh [start|stop|status] [datadir] [port] [user] [pass]
+# Usage: ./bitcoind_manager.sh [start|stop|status] [datadir] [port] [user] [pass] [-extra-bitcoind-flag...]
+#
+# Positional args beyond [pass] are forwarded verbatim to bitcoind on start
+# (e.g. -debug=mempool, -vbparams=..., -acceptnonstdtxn). Stop and status
+# ignore them.
 
 # Use parameters or defaults
 DATADIR="${2:-$(pwd)/bitcoind_regtest}"
 RPC_PORT="${3:-18443}"
 RPC_USER="${4:-user}"
 RPC_PASS="${5:-pass}"
+EXTRA_ARGS=("${@:6}")
 
 # Function to check if bitcoind is running
 is_running() {
@@ -37,9 +42,12 @@ start_bitcoind() {
     # Calculate P2P port (RPC_PORT + 1)
     P2P_PORT=$((RPC_PORT + 1))
     
-    # Start bitcoind
+    # Start bitcoind. Args after the fixed positional set (EXTRA_ARGS) are
+    # forwarded verbatim from Config.ExtraArgs on the Go side. Wrap in `if !`
+    # so unknown-flag errors fail fast instead of waiting for the polling
+    # loop to time out.
     echo "Starting bitcoind in regtest mode..."
-    bitcoind \
+    if ! bitcoind \
         -regtest \
         -datadir="$DATADIR" \
         -server \
@@ -51,11 +59,16 @@ start_bitcoind() {
         -rpcallowip=127.0.0.1 \
         -fallbackfee=0.0002 \
         -txindex \
-        -daemon
+        -daemon \
+        "${EXTRA_ARGS[@]}"; then
+        echo "ERROR: bitcoind exited non-zero on launch (likely invalid flag)"
+        exit 1
+    fi
     
-    # Wait for bitcoind to be ready
+    # Wait for bitcoind to be ready. Bumped from 20 to 40 iterations (20s) so
+    # slow startup flags like -reindex or large -dbcache values don't time out.
     echo "Waiting for bitcoind to be ready..."
-    for i in {1..20}; do
+    for i in {1..40}; do
         if bitcoin-cli -regtest -rpcuser="$RPC_USER" -rpcpassword="$RPC_PASS" -rpcport="$RPC_PORT" getblockcount >/dev/null 2>&1; then
             echo "bitcoind is ready!"
             exit 0


### PR DESCRIPTION
## Summary

Fixes #66. `Config.ExtraArgs` is advertised (regtest.go:37-39) and defensively copied, but `scripts/bitcoind_manager.sh` hardcoded the bitcoind invocation and `StartContext` never forwarded the field to the script. Today, `Config.ExtraArgs = []string{"-txindex=1"}` silently does nothing. This blocks every flag-based soft-fork workflow (`-vbparams`, `-acceptnonstdtxn`, `-debug=*`, `-testactivationheight`, etc.).

## Changes

**`scripts/bitcoind_manager.sh`**
- Capture positional args 6+ as `EXTRA_ARGS` array.
- Append `"${EXTRA_ARGS[@]}"` to the bitcoind invocation on start.
- Wrap the bitcoind launch in `if ! … fi` so unknown-flag errors fail fast (Test_ExtraArgs_UnknownFlag now exits in ~40ms instead of waiting 20s for the polling loop).
- Bump polling loop from 20 to 40 iterations (10s → 20s) to absorb slow-startup flags like `-reindex` or large `-dbcache` values.

**`regtest.go`**
- `StartContext` appends `r.config.ExtraArgs...` to the `exec.CommandContext` argv.
- `Stop` is intentionally **not** changed: `stop_bitcoind` only reads `$2..$5` and never references `"$@"`, so there's nothing to forward.

**Tests** (port 19600/19601)
- `Test_ExtraArgs_Forwarded`: starts with `-debug=mempool`, calls the `logging` RPC, asserts `mempool=true`. Pins that ExtraArgs actually reach bitcoind.
- `Test_ExtraArgs_UnknownFlag`: starts with `-this-flag-does-not-exist=1`, asserts `Start` returns an error. Pins the fast-fail contract.

## Test plan

- [x] `make ai-check` clean (fmt + vet + lint + test-race + vuln)
- [x] `Test_ExtraArgs_Forwarded` PASS (3.73s)
- [x] `Test_ExtraArgs_UnknownFlag` PASS (0.04s — confirms fast-fail wrapper)
- [x] All existing tests still PASS

## Notes

This is PR 1/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Unblocks #67 (VBParams), #73 (AcceptNonstdTxn), and the rest of Phase 5.