### PR TITLE
[Phase 5.A.3 + 5.C.4] Chain-state RPC wrappers

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -1,0 +1,282 @@
+package regtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// BlockChainInfo is a curated subset of bitcoind's getblockchaininfo response.
+// Only fields stable across Bitcoin Core versions are included; the legacy
+// softforks/deployments shape (which has shifted between Core releases) is
+// intentionally omitted — use GetDeploymentInfo for soft-fork state.
+type BlockChainInfo struct {
+	Chain                string  `json:"chain"`
+	Blocks               int64   `json:"blocks"`
+	Headers              int64   `json:"headers"`
+	BestBlockHash        string  `json:"bestblockhash"`
+	Difficulty           float64 `json:"difficulty"`
+	MedianTime           int64   `json:"mediantime"`
+	InitialBlockDownload bool    `json:"initialblockdownload"`
+	Chainwork            string  `json:"chainwork"`
+	Pruned               bool    `json:"pruned"`
+}
+
+// GetBlockChainInfo returns curated chain-state information from bitcoind.
+//
+// This wrapper uses the raw getblockchaininfo RPC rather than btcd's typed
+// GetBlockChainInfo, which issues a second getnetworkinfo call internally and
+// applies version-specific unmarshaling that has historically broken across
+// Bitcoin Core releases (compare BroadcastTransaction in tx.go for the same
+// pattern).
+//
+// Returns:
+//   - *BlockChainInfo: chain, height, best block hash, etc.
+//   - error: errNotConnected if Start has not been called; otherwise the
+//     wrapped RPC or unmarshal error.
+//
+// Example:
+//
+//	info, err := rt.GetBlockChainInfo()
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("chain=%s height=%d\n", info.Chain, info.Blocks)
+func (r *Regtest) GetBlockChainInfo() (*BlockChainInfo, error) {
+	return r.GetBlockChainInfoContext(context.Background())
+}
+
+// GetBlockChainInfoContext is the context-aware variant of GetBlockChainInfo.
+func (r *Regtest) GetBlockChainInfoContext(ctx context.Context) (*BlockChainInfo, error) {
+	raw, err := r.rawRPC(ctx, "getblockchaininfo")
+	if err != nil {
+		return nil, fmt.Errorf("getblockchaininfo: %w", err)
+	}
+	var info BlockChainInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("unmarshal getblockchaininfo: %w", err)
+	}
+	return &info, nil
+}
+
+// GetBestBlockHash returns the hash of the best (tip) block in the longest chain.
+//
+// Returns:
+//   - *chainhash.Hash: hash of the chain tip
+//   - error: errNotConnected if Start has not been called; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	hash, err := rt.GetBestBlockHash()
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println("tip:", hash)
+func (r *Regtest) GetBestBlockHash() (*chainhash.Hash, error) {
+	return r.GetBestBlockHashContext(context.Background())
+}
+
+// GetBestBlockHashContext is the context-aware variant of GetBestBlockHash.
+func (r *Regtest) GetBestBlockHashContext(ctx context.Context) (*chainhash.Hash, error) {
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	hash, err := runWithContext(ctx, client.GetBestBlockHash)
+	if err != nil {
+		return nil, fmt.Errorf("getbestblockhash: %w", err)
+	}
+	return hash, nil
+}
+
+// GetBlockHash returns the hash of the block at the given height.
+//
+// Parameters:
+//   - height: block height (>= 0)
+//
+// Returns:
+//   - *chainhash.Hash: hash of the block at height
+//   - error: errNotConnected if Start has not been called; otherwise wrapped RPC error
+//     (e.g. block height out of range).
+//
+// Example:
+//
+//	hash, err := rt.GetBlockHash(101)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println("block 101:", hash)
+func (r *Regtest) GetBlockHash(height int64) (*chainhash.Hash, error) {
+	return r.GetBlockHashContext(context.Background(), height)
+}
+
+// GetBlockHashContext is the context-aware variant of GetBlockHash.
+func (r *Regtest) GetBlockHashContext(ctx context.Context, height int64) (*chainhash.Hash, error) {
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	hash, err := runWithContext(ctx, func() (*chainhash.Hash, error) {
+		return client.GetBlockHash(height)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getblockhash %d: %w", height, err)
+	}
+	return hash, nil
+}
+
+// GetBlock returns the deserialized block (raw form) for the given hash.
+//
+// Parameters:
+//   - hash: block hash (must be non-nil)
+//
+// Returns:
+//   - *wire.MsgBlock: the deserialized block
+//   - error: validation error for nil hash; errNotConnected if Start has not
+//     been called; otherwise wrapped RPC error (e.g. block not found).
+//
+// Example:
+//
+//	block, err := rt.GetBlock(hash)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("block has %d txs\n", len(block.Transactions))
+func (r *Regtest) GetBlock(hash *chainhash.Hash) (*wire.MsgBlock, error) {
+	return r.GetBlockContext(context.Background(), hash)
+}
+
+// GetBlockContext is the context-aware variant of GetBlock.
+func (r *Regtest) GetBlockContext(ctx context.Context, hash *chainhash.Hash) (*wire.MsgBlock, error) {
+	if hash == nil {
+		return nil, fmt.Errorf("hash must not be nil")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	block, err := runWithContext(ctx, func() (*wire.MsgBlock, error) {
+		return client.GetBlock(hash)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getblock %s: %w", hash, err)
+	}
+	return block, nil
+}
+
+// GetBlockVerbose returns the verbose JSON form of the block (with tx ids,
+// confirmations, height, etc.) for the given hash.
+//
+// Parameters:
+//   - hash: block hash (must be non-nil)
+//
+// Returns:
+//   - *btcjson.GetBlockVerboseResult: the verbose result
+//   - error: validation error for nil hash; errNotConnected if Start has not
+//     been called; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	v, err := rt.GetBlockVerbose(hash)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Printf("height=%d confirmations=%d\n", v.Height, v.Confirmations)
+func (r *Regtest) GetBlockVerbose(hash *chainhash.Hash) (*btcjson.GetBlockVerboseResult, error) {
+	return r.GetBlockVerboseContext(context.Background(), hash)
+}
+
+// GetBlockVerboseContext is the context-aware variant of GetBlockVerbose.
+func (r *Regtest) GetBlockVerboseContext(ctx context.Context, hash *chainhash.Hash) (*btcjson.GetBlockVerboseResult, error) {
+	if hash == nil {
+		return nil, fmt.Errorf("hash must not be nil")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := runWithContext(ctx, func() (*btcjson.GetBlockVerboseResult, error) {
+		return client.GetBlockVerbose(hash)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getblock verbose %s: %w", hash, err)
+	}
+	return res, nil
+}
+
+// GetBlockHeader returns the deserialized header for the given block hash.
+//
+// Parameters:
+//   - hash: block hash (must be non-nil)
+//
+// Returns:
+//   - *wire.BlockHeader: the deserialized header
+//   - error: validation error for nil hash; errNotConnected if Start has not
+//     been called; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	hdr, err := rt.GetBlockHeader(hash)
+//	if err != nil {
+//	    return err
+//	}
+//	fmt.Println("merkle root:", hdr.MerkleRoot)
+func (r *Regtest) GetBlockHeader(hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	return r.GetBlockHeaderContext(context.Background(), hash)
+}
+
+// GetBlockHeaderContext is the context-aware variant of GetBlockHeader.
+func (r *Regtest) GetBlockHeaderContext(ctx context.Context, hash *chainhash.Hash) (*wire.BlockHeader, error) {
+	if hash == nil {
+		return nil, fmt.Errorf("hash must not be nil")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	hdr, err := runWithContext(ctx, func() (*wire.BlockHeader, error) {
+		return client.GetBlockHeader(hash)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getblockheader %s: %w", hash, err)
+	}
+	return hdr, nil
+}
+
+// GetChainTips returns information about all known tips in the block tree
+// (active main chain plus any orphan branches).
+//
+// Returns:
+//   - []*btcjson.GetChainTipsResult: one entry per tip; on a linear chain there
+//     is exactly one with Status == "active"
+//   - error: errNotConnected if Start has not been called; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	tips, err := rt.GetChainTips()
+//	if err != nil {
+//	    return err
+//	}
+//	for _, tip := range tips {
+//	    fmt.Printf("tip %s height=%d status=%s\n", tip.Hash, tip.Height, tip.Status)
+//	}
+func (r *Regtest) GetChainTips() ([]*btcjson.GetChainTipsResult, error) {
+	return r.GetChainTipsContext(context.Background())
+}
+
+// GetChainTipsContext is the context-aware variant of GetChainTips.
+func (r *Regtest) GetChainTipsContext(ctx context.Context) ([]*btcjson.GetChainTipsResult, error) {
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	tips, err := runWithContext(ctx, client.GetChainTips)
+	if err != nil {
+		return nil, fmt.Errorf("getchaintips: %w", err)
+	}
+	return tips, nil
+}

--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -606,3 +606,123 @@ func TestRPC_Concurrent_WarpAndSend(t *testing.T) {
 		t.Errorf("concurrent op failed: %v", err)
 	}
 }
+
+// TestRPC_ChainState exercises the chain inspection wrappers added in
+// chain.go: GetBlockChainInfo, GetBestBlockHash, GetBlockHash, GetBlock,
+// GetBlockVerbose, GetBlockHeader, GetChainTips. After mining 10 blocks the
+// tip hash should agree across queries and there should be exactly one
+// active tip on the linear chain.
+func TestRPC_ChainState(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(minerWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(minerWallet)
+
+	addr, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+	if err := rt.Warp(10, addr); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	info, err := rt.GetBlockChainInfo()
+	if err != nil {
+		t.Fatalf("GetBlockChainInfo: %v", err)
+	}
+	if info.Chain != "regtest" {
+		t.Errorf("expected Chain=regtest, got %q", info.Chain)
+	}
+	if info.Blocks < 10 {
+		t.Errorf("expected Blocks >= 10, got %d", info.Blocks)
+	}
+	if info.BestBlockHash == "" {
+		t.Error("BestBlockHash empty")
+	}
+
+	bestHash, err := rt.GetBestBlockHash()
+	if err != nil {
+		t.Fatalf("GetBestBlockHash: %v", err)
+	}
+	if bestHash.String() != info.BestBlockHash {
+		t.Errorf("GetBestBlockHash %s != info.BestBlockHash %s", bestHash, info.BestBlockHash)
+	}
+
+	tipHash, err := rt.GetBlockHash(info.Blocks)
+	if err != nil {
+		t.Fatalf("GetBlockHash(%d): %v", info.Blocks, err)
+	}
+	if !tipHash.IsEqual(bestHash) {
+		t.Errorf("GetBlockHash(tip) %s != GetBestBlockHash %s", tipHash, bestHash)
+	}
+
+	block, err := rt.GetBlock(bestHash)
+	if err != nil {
+		t.Fatalf("GetBlock: %v", err)
+	}
+	if len(block.Transactions) == 0 {
+		t.Error("expected at least one tx (coinbase) in block")
+	}
+
+	verbose, err := rt.GetBlockVerbose(bestHash)
+	if err != nil {
+		t.Fatalf("GetBlockVerbose: %v", err)
+	}
+	if verbose.Height != info.Blocks {
+		t.Errorf("verbose Height %d != info.Blocks %d", verbose.Height, info.Blocks)
+	}
+
+	hdr, err := rt.GetBlockHeader(bestHash)
+	if err != nil {
+		t.Fatalf("GetBlockHeader: %v", err)
+	}
+	if hdr == nil {
+		t.Error("GetBlockHeader returned nil header")
+	}
+
+	tips, err := rt.GetChainTips()
+	if err != nil {
+		t.Fatalf("GetChainTips: %v", err)
+	}
+	activeCount := 0
+	for _, tip := range tips {
+		if tip.Status == "active" {
+			activeCount++
+		}
+	}
+	if activeCount != 1 {
+		t.Errorf("expected exactly 1 active tip on linear chain, got %d (tips=%+v)", activeCount, tips)
+	}
+}
+
+// TestRPC_ChainState_NilHash pins the validation contract that hash-taking
+// chain wrappers reject nil rather than panicking.
+func TestRPC_ChainState_NilHash(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if _, err := rt.GetBlock(nil); err == nil {
+		t.Error("GetBlock(nil) should return validation error")
+	}
+	if _, err := rt.GetBlockVerbose(nil); err == nil {
+		t.Error("GetBlockVerbose(nil) should return validation error")
+	}
+	if _, err := rt.GetBlockHeader(nil); err == nil {
+		t.Error("GetBlockHeader(nil) should return validation error")
+	}
+}

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 )
 
@@ -366,6 +367,13 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 		{"Warp", func() error {
 			return rt.Warp(1, "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl")
 		}},
+		{"GetBlockChainInfo", func() error { _, err := rt.GetBlockChainInfo(); return err }},
+		{"GetBestBlockHash", func() error { _, err := rt.GetBestBlockHash(); return err }},
+		{"GetBlockHash", func() error { _, err := rt.GetBlockHash(0); return err }},
+		{"GetBlock", func() error { _, err := rt.GetBlock(&chainhash.Hash{}); return err }},
+		{"GetBlockVerbose", func() error { _, err := rt.GetBlockVerbose(&chainhash.Hash{}); return err }},
+		{"GetBlockHeader", func() error { _, err := rt.GetBlockHeader(&chainhash.Hash{}); return err }},
+		{"GetChainTips", func() error { _, err := rt.GetChainTips(); return err }},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #68 and #77. Adds typed Go wrappers for the chain-state inspection RPCs in a new `chain.go`. These are foundation pieces for the soft-fork roadmap (Phase 5) — every reorg / fork-choice / deployment test needs to look up block hashes, headers, and tips.

## Changes

**New file `chain.go`**

- `GetBlockChainInfo` / `...Context` — uses `rawRPC("getblockchaininfo")` + a curated `BlockChainInfo` struct. Deliberately bypasses btcd's typed wrapper, which issues a second `getnetworkinfo` RPC and applies version-specific unmarshaling that has historically broken across Bitcoin Core releases (compare `tx.go:259-262` for the same pattern around `BroadcastTransaction`). The legacy `softforks` shape is intentionally omitted — soft-fork state belongs in `GetDeploymentInfo` (#69).
- `GetBestBlockHash`, `GetBlockHash`, `GetBlock`, `GetBlockVerbose`, `GetBlockHeader`, `GetChainTips` — typed btcsuite via `runWithContext`.
- All wrappers have `Context`-suffixed variants per repo convention.
- Hash-taking wrappers (`GetBlock` / `GetBlockVerbose` / `GetBlockHeader`) reject nil rather than panicking.

**Tests**

- `TestRPC_ChainState`: mines 10 blocks, asserts `chain="regtest"`, that the tip hash agrees across `GetBestBlockHash` / `GetBlockHash(tip)` / `GetBlockChainInfo.BestBlockHash`, that `GetBlock` returns at least one tx (coinbase), `GetBlockVerbose.Height` matches, and that there is exactly one active tip on the linear chain.
- `TestRPC_ChainState_NilHash`: pins the validation contract for the three hash-taking wrappers.
- `Test_RPCMethods_BeforeStart` extended with the seven new methods — they must all return `errNotConnected` when called before `Start`.

## Test plan

- [x] `make ai-check` clean (fmt + vet + lint + test-race + vuln)
- [x] `TestRPC_ChainState` PASS (4.00s)
- [x] `TestRPC_ChainState_NilHash` PASS (3.72s)
- [x] All seven new BeforeStart subtests PASS
- [x] All existing tests still PASS

## Notes

PR 2/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Follows PR #84 (#66, ExtraArgs forwarding) which has already merged.