### PR TITLE
[Phase 5.A.4] Typed GetDeploymentInfo wrapper

### DIFF
--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -704,6 +704,60 @@ func TestRPC_ChainState(t *testing.T) {
 	}
 }
 
+// TestRPC_GetDeploymentInfo exercises the typed getdeploymentinfo wrapper.
+// On a default regtest node we expect entries for the well-known buried
+// deployments (taproot, segwit, csv) — taproot is active from block 0 on
+// modern Core so its Active flag must be true.
+//
+// This test requires Bitcoin Core 24+ for the underlying RPC; on older
+// builds it will report a clear failure pointing at that minimum version.
+func TestRPC_GetDeploymentInfo(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	info, err := rt.GetDeploymentInfo()
+	if err != nil {
+		t.Fatalf("GetDeploymentInfo (requires Bitcoin Core 24+): %v", err)
+	}
+	if info.Hash == "" {
+		t.Error("Hash empty")
+	}
+	if info.Deployments == nil {
+		t.Fatal("Deployments map nil")
+	}
+
+	for _, name := range []string{"taproot", "segwit", "csv"} {
+		d, ok := info.Deployments[name]
+		if !ok {
+			t.Errorf("missing deployment %q in %v", name, deploymentNames(info.Deployments))
+			continue
+		}
+		if d.Type != "buried" && d.Type != "bip9" {
+			t.Errorf("%s: unexpected Type %q", name, d.Type)
+		}
+	}
+
+	if d, ok := info.Deployments["taproot"]; ok {
+		if !d.Active {
+			t.Errorf("taproot expected Active=true on modern regtest, got %+v", d)
+		}
+	}
+}
+
+func deploymentNames(m map[string]Deployment) []string {
+	names := make([]string, 0, len(m))
+	for k := range m {
+		names = append(names, k)
+	}
+	return names
+}
+
 // TestRPC_ChainState_NilHash pins the validation contract that hash-taking
 // chain wrappers reject nil rather than panicking.
 func TestRPC_ChainState_NilHash(t *testing.T) {

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -374,6 +374,7 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 		{"GetBlockVerbose", func() error { _, err := rt.GetBlockVerbose(&chainhash.Hash{}); return err }},
 		{"GetBlockHeader", func() error { _, err := rt.GetBlockHeader(&chainhash.Hash{}); return err }},
 		{"GetChainTips", func() error { _, err := rt.GetChainTips(); return err }},
+		{"GetDeploymentInfo", func() error { _, err := rt.GetDeploymentInfo(); return err }},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {

--- a/softfork.go
+++ b/softfork.go
@@ -1,0 +1,127 @@
+// Package regtest soft-fork support.
+//
+// The types and methods in this file expose Bitcoin Core's BIP9 deployment
+// state machine to Go callers — the underpinnings for testing future soft
+// forks (APO/eltoo, CTV/LNHANCE, CSFS, etc.) deterministically against a
+// regtest node.
+//
+// Minimum bitcoind version: Bitcoin Core 24. The getdeploymentinfo RPC was
+// introduced in v24; against older bitcoind builds these methods will surface
+// the underlying RPC error from rawRPC and tests can skip cleanly.
+package regtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// DeploymentInfo is the typed shape of bitcoind's getdeploymentinfo response.
+// It describes the BIP9 deployment state machine evaluated as of a specific
+// block hash and height.
+type DeploymentInfo struct {
+	// Hash is the block hash the deployments were evaluated against.
+	Hash string `json:"hash"`
+	// Height is the block height the deployments were evaluated against.
+	Height int64 `json:"height"`
+	// Deployments maps deployment name (e.g. "testdummy", "taproot",
+	// "anyprevout") to its current state. The set of names depends on the
+	// bitcoind binary in use.
+	Deployments map[string]Deployment `json:"deployments"`
+}
+
+// Deployment describes a single soft-fork deployment's state. Bitcoin Core
+// distinguishes "buried" deployments (active for so long they're embedded in
+// the consensus rules — Type=="buried") from "bip9" deployments (still
+// signaling and capable of state transitions — Type=="bip9").
+type Deployment struct {
+	// Type is "bip9" for active BIP9 deployments or "buried" for deployments
+	// hard-coded as always active.
+	Type string `json:"type"`
+	// Active reports whether the deployment is currently enforced as of Hash.
+	Active bool `json:"active"`
+	// Height is the activation height for buried deployments and the
+	// activation block height for active BIP9 deployments. Zero for BIP9
+	// deployments that have not yet activated.
+	Height int64 `json:"height"`
+	// BIP9 carries the BIP9 state machine details for Type=="bip9"; nil for
+	// buried deployments.
+	BIP9 *BIP9Info `json:"bip9,omitempty"`
+}
+
+// BIP9Info is the per-deployment BIP9 state, as reported under the "bip9"
+// field of getdeploymentinfo.
+type BIP9Info struct {
+	// Status is the current BIP9 state: defined, started, locked_in, active,
+	// or failed.
+	Status string `json:"status"`
+	// StatusNext is the projected status at the next retarget boundary
+	// (Bitcoin Core 25+).
+	StatusNext string `json:"status_next,omitempty"`
+	// Bit is the version bit signaled for this deployment.
+	Bit int `json:"bit"`
+	// StartTime is the unix timestamp at which signaling may begin.
+	StartTime int64 `json:"start_time"`
+	// Timeout is the unix timestamp after which the deployment fails.
+	Timeout int64 `json:"timeout"`
+	// MinActivationHeight is the BIP9 minimum-activation-height field.
+	MinActivationHeight int32 `json:"min_activation_height"`
+	// Since is the height at which the current Status was reached.
+	Since int64 `json:"since"`
+	// Statistics carries signaling statistics for status=="started"
+	// deployments; nil otherwise.
+	Statistics *BIP9Statistics `json:"statistics,omitempty"`
+}
+
+// BIP9Statistics describes BIP9 signaling progress within the current
+// retarget window.
+type BIP9Statistics struct {
+	// Period is the length of the retarget window in blocks.
+	Period int `json:"period"`
+	// Threshold is the number of signaling blocks required to lock in.
+	Threshold int `json:"threshold"`
+	// Elapsed is the number of blocks evaluated so far in the window.
+	Elapsed int `json:"elapsed"`
+	// Count is the number of signaling blocks observed so far.
+	Count int `json:"count"`
+	// Possible is true if Threshold is still reachable in the current window.
+	Possible bool `json:"possible"`
+}
+
+// GetDeploymentInfo returns the BIP9 soft-fork deployment state evaluated
+// against the chain tip. This is the canonical way to inspect activation
+// progress for both buried (e.g. "taproot", "segwit") and active BIP9
+// deployments (e.g. "testdummy", or — against bitcoin-inquisition builds —
+// "anyprevout", "checktemplateverify").
+//
+// Returns:
+//   - *DeploymentInfo: typed deployment state map keyed by deployment name
+//   - error: errNotConnected if Start has not been called; otherwise the
+//     wrapped RPC or unmarshal error. On Bitcoin Core older than v24 the RPC
+//     itself is absent; callers can skip on that error.
+//
+// Example:
+//
+//	info, err := rt.GetDeploymentInfo()
+//	if err != nil {
+//	    return err
+//	}
+//	if d, ok := info.Deployments["taproot"]; ok && d.Active {
+//	    fmt.Println("taproot active at height", d.Height)
+//	}
+func (r *Regtest) GetDeploymentInfo() (*DeploymentInfo, error) {
+	return r.GetDeploymentInfoContext(context.Background())
+}
+
+// GetDeploymentInfoContext is the context-aware variant of GetDeploymentInfo.
+func (r *Regtest) GetDeploymentInfoContext(ctx context.Context) (*DeploymentInfo, error) {
+	raw, err := r.rawRPC(ctx, "getdeploymentinfo")
+	if err != nil {
+		return nil, fmt.Errorf("getdeploymentinfo: %w", err)
+	}
+	var info DeploymentInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, fmt.Errorf("unmarshal getdeploymentinfo: %w", err)
+	}
+	return &info, nil
+}


### PR DESCRIPTION
## Summary

Closes #69. Adds the typed `getdeploymentinfo` wrapper — the canonical API for inspecting BIP9 soft-fork state. This is the foundation that PR 4b (`DeploymentStatus`, `SoftForkStatus`) and PR 7 (testdummy acceptance test) will build on.

## Changes

**New file `softfork.go`**

- Types: `DeploymentInfo`, `Deployment`, `BIP9Info`, `BIP9Statistics`. Field tags match Core's JSON exactly (e.g. `min_activation_height`, `status_next`).
- `GetDeploymentInfo` / `...Context` via `rawRPC("getdeploymentinfo")` + `json.Unmarshal`. btcsuite has no typed wrapper for this RPC (introduced in Core 24), so `rawRPC` is the only option.
- Package-level godoc on `softfork.go` documents the Core 24+ minimum so callers know what to expect.

**Tests**

- `TestRPC_GetDeploymentInfo`: asserts `Hash` is populated, the `Deployments` map contains the well-known buried deployments (`taproot`, `segwit`, `csv`), and that `taproot.Active == true` on modern regtest. Reports a clear failure message pointing at the Core 24+ minimum if the underlying RPC is absent.
- `Test_RPCMethods_BeforeStart` extended with `GetDeploymentInfo` to pin the `errNotConnected` pre-Start contract.

## Test plan

- [x] `make ai-check` clean
- [x] `TestRPC_GetDeploymentInfo` PASS (3.73s)
- [x] `Test_RPCMethods_BeforeStart/GetDeploymentInfo` PASS
- [x] All existing tests still PASS

## Notes

PR 3/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Unblocks #72 (PR 4b: DeploymentStatus + SoftForkStatus enum) and #71 (PR 8: MineUntilActive helper).