### PR TITLE
[Phase 5.A.2 + 5.B.4] VBParams + AcceptNonstdTxn config layer

### DIFF
--- a/regtest.go
+++ b/regtest.go
@@ -37,6 +37,17 @@ type Config struct {
 	// Additional bitcoind arguments (optional)
 	// Example: []string{"-txindex=1", "-fallbackfee=0.0001"}
 	ExtraArgs []string
+
+	// VBParams configures named BIP9 deployments. Each entry renders to one
+	// -vbparams=<name>:<start>:<timeout>:<min_activation_height> flag. See
+	// VBParam, VBAlwaysActive, and VBNeverActive in softfork.go.
+	VBParams []VBParam
+
+	// AcceptNonstdTxn maps to -acceptnonstdtxn=1 when true. Pre-standardness
+	// soft-fork transactions (APO sigs, CTV-committed outputs, etc.) are
+	// consensus-valid but mempool-rejected by default; flip this on for any
+	// test that needs to broadcast such a tx through the mempool. Default false.
+	AcceptNonstdTxn bool
 }
 
 // Regtest manages a Bitcoin regtest node instance.
@@ -86,11 +97,21 @@ func New(config *Config) (*Regtest, error) {
 	} else {
 		// Store a copy to prevent external modifications
 		rt.config = &Config{
-			Host:      config.Host,
-			User:      config.User,
-			Pass:      config.Pass,
-			DataDir:   config.DataDir,
-			ExtraArgs: append([]string(nil), config.ExtraArgs...),
+			Host:            config.Host,
+			User:            config.User,
+			Pass:            config.Pass,
+			DataDir:         config.DataDir,
+			ExtraArgs:       append([]string(nil), config.ExtraArgs...),
+			VBParams:        append([]VBParam(nil), config.VBParams...),
+			AcceptNonstdTxn: config.AcceptNonstdTxn,
+		}
+	}
+
+	// Validate VBParams: empty Deployment is a configuration mistake we
+	// catch eagerly rather than letting bitcoind silently ignore the flag.
+	for i, vb := range rt.config.VBParams {
+		if vb.Deployment == "" {
+			return nil, fmt.Errorf("VBParams[%d].Deployment must not be empty", i)
 		}
 	}
 
@@ -131,11 +152,13 @@ func DefaultConfig() *Config {
 //   - *Config: A copy of the configuration
 func (r *Regtest) Config() *Config {
 	return &Config{
-		Host:      r.config.Host,
-		User:      r.config.User,
-		Pass:      r.config.Pass,
-		DataDir:   r.config.DataDir,
-		ExtraArgs: append([]string(nil), r.config.ExtraArgs...),
+		Host:            r.config.Host,
+		User:            r.config.User,
+		Pass:            r.config.Pass,
+		DataDir:         r.config.DataDir,
+		ExtraArgs:       append([]string(nil), r.config.ExtraArgs...),
+		VBParams:        append([]VBParam(nil), r.config.VBParams...),
+		AcceptNonstdTxn: r.config.AcceptNonstdTxn,
 	}
 }
 
@@ -217,8 +240,10 @@ func (r *Regtest) StartContext(ctx context.Context) error {
 	port := r.extractPort()
 
 	// Pass config parameters to script: start datadir port user pass [extra-args...].
-	// ExtraArgs are forwarded verbatim to bitcoind by the script (see scripts/bitcoind_manager.sh).
-	scriptArgs := append([]string{r.scriptPath, "start", r.config.DataDir, port, r.config.User, r.config.Pass}, r.config.ExtraArgs...)
+	// renderExtraArgs combines Config.ExtraArgs with rendered VBParams and
+	// -acceptnonstdtxn; the script forwards them verbatim to bitcoind (see
+	// scripts/bitcoind_manager.sh).
+	scriptArgs := append([]string{r.scriptPath, "start", r.config.DataDir, port, r.config.User, r.config.Pass}, r.config.renderExtraArgs()...)
 	cmd := exec.CommandContext(ctx, "bash", scriptArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -4,13 +4,38 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 )
+
+// testdummyConfig builds a Config that points bitcoind at a fresh data dir
+// (auto-cleaned by t.TempDir) on the given port, with -acceptnonstdtxn=1 and
+// the testdummy BIP9 deployment configured for fast activation. Shared by
+// soft-fork tests so the activation parameters stay consistent.
+func testdummyConfig(t *testing.T, port int) *Config {
+	t.Helper()
+	return &Config{
+		Host:            fmt.Sprintf("127.0.0.1:%d", port),
+		User:            "user",
+		Pass:            "pass",
+		DataDir:         filepath.Join(t.TempDir(), "regtest"),
+		AcceptNonstdTxn: true,
+		VBParams: []VBParam{{
+			Deployment:          "testdummy",
+			StartTime:           0,
+			Timeout:             9999999999,
+			MinActivationHeight: 0,
+		}},
+	}
+}
 
 func Test_Regtest(t *testing.T) {
 	// Create new regtest instance with default config
@@ -79,11 +104,13 @@ func Test_Config(t *testing.T) {
 
 	// Test creating instance with custom config
 	customCfg := &Config{
-		Host:      "127.0.0.1:18444",
-		User:      "testuser",
-		Pass:      "testpass",
-		DataDir:   "/tmp/test_regtest",
-		ExtraArgs: []string{"-txindex=1"},
+		Host:            "127.0.0.1:18444",
+		User:            "testuser",
+		Pass:            "testpass",
+		DataDir:         "/tmp/test_regtest",
+		ExtraArgs:       []string{"-txindex=1"},
+		VBParams:        []VBParam{VBAlwaysActive("testdummy")},
+		AcceptNonstdTxn: true,
 	}
 	rt2, err := New(customCfg)
 	if err != nil {
@@ -106,6 +133,12 @@ func Test_Config(t *testing.T) {
 	}
 	if len(cfg2.ExtraArgs) != 1 || cfg2.ExtraArgs[0] != "-txindex=1" {
 		t.Errorf("expected extra args [-txindex=1], got %v", cfg2.ExtraArgs)
+	}
+	if len(cfg2.VBParams) != 1 || cfg2.VBParams[0].Deployment != "testdummy" {
+		t.Errorf("expected VBParams [testdummy], got %v", cfg2.VBParams)
+	}
+	if !cfg2.AcceptNonstdTxn {
+		t.Error("expected AcceptNonstdTxn=true to round-trip")
 	}
 
 	// Test that RPCConfig uses the instance's config
@@ -479,6 +512,204 @@ func Test_Context_Cancellation(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 		t.Errorf("expected ctx error, got %v", err)
+	}
+}
+
+// Test_TestdummyConfig pins the shape of the shared testdummyConfig helper
+// so future soft-fork tests (#71, #81) can rely on it. No node spawned.
+func Test_TestdummyConfig(t *testing.T) {
+	cfg := testdummyConfig(t, 19702)
+	if cfg.Host != "127.0.0.1:19702" {
+		t.Errorf("Host = %q, want 127.0.0.1:19702", cfg.Host)
+	}
+	if !cfg.AcceptNonstdTxn {
+		t.Error("expected AcceptNonstdTxn=true")
+	}
+	if len(cfg.VBParams) != 1 {
+		t.Fatalf("expected 1 VBParam, got %d", len(cfg.VBParams))
+	}
+	vb := cfg.VBParams[0]
+	if vb.Deployment != "testdummy" {
+		t.Errorf("Deployment = %q, want testdummy", vb.Deployment)
+	}
+	if vb.StartTime != 0 || vb.Timeout != 9999999999 || vb.MinActivationHeight != 0 {
+		t.Errorf("VBParam = %+v, want {testdummy 0 9999999999 0}", vb)
+	}
+}
+
+// Test_VBParams_Render unit-tests Config.renderExtraArgs (no node spawned).
+// Pins the wire format for -vbparams and the composition order:
+// ExtraArgs first, then VBParams in declaration order, then -acceptnonstdtxn.
+func Test_VBParams_Render(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  Config
+		want []string
+	}{
+		{
+			name: "empty",
+			cfg:  Config{},
+			want: nil,
+		},
+		{
+			name: "extra-args-only",
+			cfg:  Config{ExtraArgs: []string{"-debug=net"}},
+			want: []string{"-debug=net"},
+		},
+		{
+			name: "vbparams-explicit",
+			cfg: Config{
+				VBParams: []VBParam{
+					{Deployment: "testdummy", StartTime: 0, Timeout: 9999999999, MinActivationHeight: 0},
+				},
+			},
+			want: []string{"-vbparams=testdummy:0:9999999999:0"},
+		},
+		{
+			name: "vbparams-helpers",
+			cfg: Config{
+				VBParams: []VBParam{
+					VBAlwaysActive("anyprevout"),
+					VBNeverActive("checktemplateverify"),
+				},
+			},
+			want: []string{
+				"-vbparams=anyprevout:-1:0:0",
+				"-vbparams=checktemplateverify:-2:0:0",
+			},
+		},
+		{
+			name: "all-three-combine-in-order",
+			cfg: Config{
+				ExtraArgs: []string{"-debug=net", "-printtoconsole=0"},
+				VBParams: []VBParam{
+					{Deployment: "testdummy", StartTime: 0, Timeout: 9999999999, MinActivationHeight: 0},
+				},
+				AcceptNonstdTxn: true,
+			},
+			want: []string{
+				"-debug=net",
+				"-printtoconsole=0",
+				"-vbparams=testdummy:0:9999999999:0",
+				"-acceptnonstdtxn=1",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.cfg.renderExtraArgs()
+			if !slices.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Test_New_EmptyVBParamDeployment pins the validation contract that an empty
+// Deployment field is rejected at New time rather than silently producing a
+// malformed -vbparams= flag.
+func Test_New_EmptyVBParamDeployment(t *testing.T) {
+	_, err := New(&Config{
+		VBParams: []VBParam{{Deployment: "", StartTime: 0, Timeout: 0, MinActivationHeight: 0}},
+	})
+	if err == nil {
+		t.Fatal("expected error from empty Deployment, got nil")
+	}
+}
+
+// Test_AcceptNonstdTxn verifies that Config.AcceptNonstdTxn maps to
+// -acceptnonstdtxn=1 and actually changes mempool policy. Combined with
+// -datacarrier=0 (which marks any OP_RETURN output as non-standard
+// regardless of payload size — robust across Core versions that have
+// relaxed OP_RETURN size limits), a tx with an OP_RETURN output should be
+// rejected by default but accepted when AcceptNonstdTxn is on.
+func Test_AcceptNonstdTxn(t *testing.T) {
+	tryBroadcast := func(t *testing.T, port int, accept bool) error {
+		t.Helper()
+		rt, err := New(&Config{
+			Host:            fmt.Sprintf("127.0.0.1:%d", port),
+			User:            "user",
+			Pass:            "pass",
+			DataDir:         filepath.Join(t.TempDir(), "regtest"),
+			ExtraArgs:       []string{"-datacarrier=0"},
+			AcceptNonstdTxn: accept,
+		})
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := rt.Start(); err != nil {
+			t.Fatalf("Start (port %d, accept=%v): %v", port, accept, err)
+		}
+		t.Cleanup(func() { _ = rt.Stop(); _ = rt.Cleanup() })
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		if err := rt.EnsureWallet("test"); err != nil {
+			t.Fatalf("EnsureWallet: %v", err)
+		}
+		addr, err := rt.GenerateBech32("test")
+		if err != nil {
+			t.Fatalf("GenerateBech32: %v", err)
+		}
+		if err := rt.Warp(101, addr); err != nil {
+			t.Fatalf("Warp: %v", err)
+		}
+
+		// Small OP_RETURN payload — combined with -datacarrier=0 the tx is
+		// non-standard regardless of size.
+		data := strings.Repeat("aa", 8)
+
+		// Create a skeleton tx with just the OP_RETURN; let the wallet fund it.
+		skelRaw, err := rt.rawRPC(ctx, "createrawtransaction",
+			[]any{}, // no manual inputs
+			map[string]any{"data": data},
+		)
+		if err != nil {
+			t.Fatalf("createrawtransaction: %v", err)
+		}
+		var skelHex string
+		if err := json.Unmarshal(skelRaw, &skelHex); err != nil {
+			t.Fatalf("unmarshal skeleton: %v", err)
+		}
+
+		fundedRaw, err := rt.rawRPC(ctx, "fundrawtransaction", skelHex)
+		if err != nil {
+			t.Fatalf("fundrawtransaction: %v", err)
+		}
+		var funded struct {
+			Hex string `json:"hex"`
+		}
+		if err := json.Unmarshal(fundedRaw, &funded); err != nil {
+			t.Fatalf("unmarshal funded: %v", err)
+		}
+
+		signedRaw, err := rt.rawRPC(ctx, "signrawtransactionwithwallet", funded.Hex)
+		if err != nil {
+			t.Fatalf("signrawtransactionwithwallet: %v", err)
+		}
+		var signed struct {
+			Hex      string `json:"hex"`
+			Complete bool   `json:"complete"`
+		}
+		if err := json.Unmarshal(signedRaw, &signed); err != nil {
+			t.Fatalf("unmarshal signed: %v", err)
+		}
+		if !signed.Complete {
+			t.Fatal("sign incomplete")
+		}
+
+		_, err = rt.rawRPC(ctx, "sendrawtransaction", signed.Hex)
+		return err
+	}
+
+	// Spacing of 10 between RPC ports avoids collision with the P2P port
+	// (RPC+1) of the prior instance, which is still alive via t.Cleanup.
+	if err := tryBroadcast(t, 19700, true); err != nil {
+		t.Errorf("AcceptNonstdTxn=true should accept large OP_RETURN, got: %v", err)
+	}
+	if err := tryBroadcast(t, 19710, false); err == nil {
+		t.Error("AcceptNonstdTxn=false should reject large OP_RETURN, got nil error")
 	}
 }
 

--- a/softfork.go
+++ b/softfork.go
@@ -88,6 +88,64 @@ type BIP9Statistics struct {
 	Possible bool `json:"possible"`
 }
 
+// VBParam configures a single named BIP9 deployment for regtest. Each VBParam
+// renders to one -vbparams=<name>:<start>:<timeout>:<min> flag passed to
+// bitcoind on Start. Bitcoin Core treats StartTime values -1 and -2 as magic
+// sentinels for ALWAYS_ACTIVE and NEVER_ACTIVE respectively (see
+// VBAlwaysActive / VBNeverActive).
+//
+// For test workflows that want to exercise the BIP9 state machine end-to-end
+// (DEFINED → STARTED → LOCKED_IN → ACTIVE), set explicit values:
+// StartTime=0, Timeout=far-future, MinActivationHeight=0. Using
+// VBAlwaysActive collapses the state machine so the deployment reports
+// active immediately — useful when an application test only needs the new
+// rules on, but it skips the activation observability path.
+type VBParam struct {
+	// Deployment is the deployment name as known to bitcoind (e.g. "testdummy",
+	// "anyprevout", "checktemplateverify"). Must not be empty.
+	Deployment string
+	// StartTime is the BIP9 nStartTime field. Use 0 for "signaling may begin
+	// immediately"; use -1 for ALWAYS_ACTIVE; use -2 for NEVER_ACTIVE.
+	StartTime int64
+	// Timeout is the BIP9 nTimeout field — a unix timestamp after which the
+	// deployment fails. Use a far-future value (e.g. 9999999999) for tests
+	// that want unlimited time.
+	Timeout int64
+	// MinActivationHeight is the BIP9 minimum-activation-height field.
+	MinActivationHeight int32
+}
+
+// VBAlwaysActive returns a VBParam that tells bitcoind the named deployment
+// is always active on regtest (Bitcoin Core's ALWAYS_ACTIVE sentinel,
+// StartTime = -1). The BIP9 state machine is collapsed: status reports active
+// from block 0 with no signaling required.
+func VBAlwaysActive(name string) VBParam {
+	return VBParam{Deployment: name, StartTime: -1, Timeout: 0, MinActivationHeight: 0}
+}
+
+// VBNeverActive returns a VBParam that tells bitcoind the named deployment is
+// never active on regtest (Bitcoin Core's NEVER_ACTIVE sentinel, StartTime =
+// -2). Useful for tests that want to verify the soft-fork-disabled path.
+func VBNeverActive(name string) VBParam {
+	return VBParam{Deployment: name, StartTime: -2, Timeout: 0, MinActivationHeight: 0}
+}
+
+// renderExtraArgs builds the slice of bitcoind flags to forward on Start.
+// It composes Config.ExtraArgs with one -vbparams=... per VBParam and
+// -acceptnonstdtxn=1 when AcceptNonstdTxn is true. The order is stable:
+// ExtraArgs first, then VBParams in declaration order, then AcceptNonstdTxn.
+func (c *Config) renderExtraArgs() []string {
+	args := append([]string(nil), c.ExtraArgs...)
+	for _, vb := range c.VBParams {
+		args = append(args, fmt.Sprintf("-vbparams=%s:%d:%d:%d",
+			vb.Deployment, vb.StartTime, vb.Timeout, vb.MinActivationHeight))
+	}
+	if c.AcceptNonstdTxn {
+		args = append(args, "-acceptnonstdtxn=1")
+	}
+	return args
+}
+
 // GetDeploymentInfo returns the BIP9 soft-fork deployment state evaluated
 // against the chain tip. This is the canonical way to inspect activation
 // progress for both buried (e.g. "taproot", "segwit") and active BIP9


### PR DESCRIPTION
## Summary

Closes #67 and #73. Adds the typed configuration surface that all subsequent soft-fork PRs build on: `VBParam` for BIP9 deployment configuration, `AcceptNonstdTxn` for relaxed mempool policy, and the `testdummyConfig` shared test helper.

## Changes

**`softfork.go`** (config-layer additions)
- `VBParam` struct (`Deployment`, `StartTime`, `Timeout`, `MinActivationHeight`) rendering to one `-vbparams=<name>:<start>:<timeout>:<min>` flag.
- `VBAlwaysActive(name)` and `VBNeverActive(name)` helpers using Bitcoin Core's `ALWAYS_ACTIVE` (-1) and `NEVER_ACTIVE` (-2) sentinel start times.
- `(c *Config) renderExtraArgs() []string` composes `ExtraArgs` + rendered VBParams + `-acceptnonstdtxn=1` in a stable order. Consumed by `StartContext`.

**`regtest.go`**
- `Config.VBParams []VBParam` and `Config.AcceptNonstdTxn bool` with godoc.
- `New()` copies both fields defensively and rejects empty `Deployment` eagerly (a malformed `-vbparams=` is silently ignored by bitcoind, so we catch it at construction time).
- `Config()` copies both fields.
- `StartContext` now passes `r.config.renderExtraArgs()` through. `Stop` is unchanged — `stop_bitcoind` doesn't read extra args.

**Shared test helper**
- `testdummyConfig(t, port)` builds a Config with the testdummy BIP9 deployment configured for fast activation (`StartTime=0, Timeout=9999999999, MinActivationHeight=0`) plus `AcceptNonstdTxn=true`. Will be consumed by PR 8 (#71 `MineUntilActive`) and PR 7 (#81 acceptance).

**Tests**
- `Test_TestdummyConfig` pins the helper's contract.
- `Test_VBParams_Render` table-driven unit test of `renderExtraArgs` across: empty, ExtraArgs only, explicit VBParams, helper-built VBParams, and all-three composition order — no node spawned.
- `Test_New_EmptyVBParamDeployment` pins the empty-Deployment validation.
- `Test_AcceptNonstdTxn` (ports 19700/19710) is an end-to-end mempool policy check: `-datacarrier=0` marks any OP_RETURN as non-standard regardless of size (robust across Core versions that have relaxed data-carrier limits), so a tx with an OP_RETURN output is rejected when `AcceptNonstdTxn=false` but accepted when true.
- `Test_Config` extended to verify VBParams and AcceptNonstdTxn defensive-copy like the other fields.

## Test plan

- [x] `make ai-check` clean (fmt + vet + lint + test-race + vuln)
- [x] All five `Test_VBParams_Render` subtests PASS
- [x] `Test_TestdummyConfig` PASS
- [x] `Test_New_EmptyVBParamDeployment` PASS
- [x] `Test_AcceptNonstdTxn` PASS (8.80s — runs two regtest instances)
- [x] All existing tests still PASS

## Notes

PR 4a/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Follows #66, #68/#77, #69. Unblocks PR 4b (#72 `DeploymentStatus` + `SoftForkStatus` enum + polling helper) and PR 7 (#81 testdummy acceptance test).