### PR TITLE
[Phase 5.B.3] SoftForkStatus + DeploymentStatus + waitForDeployment

### DIFF
--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -2,12 +2,15 @@ package regtest
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
@@ -701,6 +704,100 @@ func TestRPC_ChainState(t *testing.T) {
 	}
 	if activeCount != 1 {
 		t.Errorf("expected exactly 1 active tip on linear chain, got %d (tips=%+v)", activeCount, tips)
+	}
+}
+
+// TestRPC_DeploymentStatus_Taproot verifies the typed DeploymentStatus
+// wrapper against the well-known buried "taproot" deployment, which is
+// always active on modern regtest from block 0.
+func TestRPC_DeploymentStatus_Taproot(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	status, err := rt.DeploymentStatus("taproot")
+	if err != nil {
+		t.Fatalf("DeploymentStatus(taproot): %v", err)
+	}
+	if status != SoftForkActive {
+		t.Errorf("taproot status = %v (%q), want SoftForkActive", status, status)
+	}
+}
+
+// TestRPC_DeploymentStatus_Unknown pins the contract that an unrecognized
+// deployment name returns ErrUnknownDeployment via errors.Is. Tests that
+// target a not-yet-mainline soft-fork (APO, CTV, CSFS) rely on this signal
+// to skip cleanly when run against mainline Core.
+func TestRPC_DeploymentStatus_Unknown(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	_, err = rt.DeploymentStatus("definitely-not-a-real-deployment")
+	if err == nil {
+		t.Fatal("expected error for unknown deployment, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeployment) {
+		t.Errorf("expected errors.Is(err, ErrUnknownDeployment), got %v", err)
+	}
+}
+
+// TestRPC_WaitForDeployment_AlreadyActive exercises the unexported polling
+// helper waitForDeployment with a target the deployment has already reached
+// (taproot=active on a fresh regtest). The helper should return on the
+// first poll without sleeping.
+func TestRPC_WaitForDeployment_AlreadyActive(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := rt.waitForDeployment(ctx, "taproot", SoftForkActive); err != nil {
+		t.Fatalf("waitForDeployment: %v", err)
+	}
+}
+
+// TestRPC_WaitForDeployment_Cancellation pins that ctx cancellation surfaces
+// rather than spinning forever when the target status will not be reached.
+func TestRPC_WaitForDeployment_Cancellation(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	// Wait for taproot=Defined — taproot is buried/active so this status
+	// will never be reported. Cancel after a short wait and confirm the
+	// helper surfaces ctx.Err().
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err = rt.waitForDeployment(ctx, "taproot", SoftForkDefined)
+	if err == nil {
+		t.Fatal("expected ctx error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Errorf("expected ctx error, got %v", err)
 	}
 }
 

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -408,6 +408,7 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 		{"GetBlockHeader", func() error { _, err := rt.GetBlockHeader(&chainhash.Hash{}); return err }},
 		{"GetChainTips", func() error { _, err := rt.GetChainTips(); return err }},
 		{"GetDeploymentInfo", func() error { _, err := rt.GetDeploymentInfo(); return err }},
+		{"DeploymentStatus", func() error { _, err := rt.DeploymentStatus("taproot"); return err }},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {
@@ -512,6 +513,38 @@ func Test_Context_Cancellation(t *testing.T) {
 	}
 	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 		t.Errorf("expected ctx error, got %v", err)
+	}
+}
+
+// Test_SoftForkStatus_String verifies that SoftForkStatus.String() returns
+// the BIP9 status strings bitcoind uses, and that parseSoftForkStatus is its
+// inverse — pinning the round-trip contract for the typed enum.
+func Test_SoftForkStatus_String(t *testing.T) {
+	cases := []struct {
+		status SoftForkStatus
+		s      string
+	}{
+		{SoftForkDefined, "defined"},
+		{SoftForkStarted, "started"},
+		{SoftForkLockedIn, "locked_in"},
+		{SoftForkActive, "active"},
+		{SoftForkFailed, "failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.s, func(t *testing.T) {
+			if got := tc.status.String(); got != tc.s {
+				t.Errorf("String() = %q, want %q", got, tc.s)
+			}
+			if got := parseSoftForkStatus(tc.s); got != tc.status {
+				t.Errorf("parseSoftForkStatus(%q) = %v, want %v", tc.s, got, tc.status)
+			}
+		})
+	}
+	if got := SoftForkUnknown.String(); got != "unknown" {
+		t.Errorf("SoftForkUnknown.String() = %q, want unknown", got)
+	}
+	if got := parseSoftForkStatus("garbage"); got != SoftForkUnknown {
+		t.Errorf("parseSoftForkStatus(garbage) = %v, want SoftForkUnknown", got)
 	}
 }
 

--- a/softfork.go
+++ b/softfork.go
@@ -13,8 +13,85 @@ package regtest
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"time"
 )
+
+// SoftForkStatus is the typed BIP9 deployment state. It collapses Bitcoin
+// Core's getdeploymentinfo "status" string into an enum so callers can match
+// without comparing strings.
+type SoftForkStatus int
+
+const (
+	// SoftForkUnknown is the zero value, returned when the BIP9 status string
+	// from bitcoind doesn't match a known state. Should not appear in
+	// practice on a healthy node.
+	SoftForkUnknown SoftForkStatus = iota
+	// SoftForkDefined is the initial BIP9 state — the deployment exists but
+	// signaling has not begun.
+	SoftForkDefined
+	// SoftForkStarted means the deployment has reached its start time and
+	// blocks may now signal support.
+	SoftForkStarted
+	// SoftForkLockedIn means the signaling threshold was met within a
+	// retarget window. Activation follows after the lock-in window.
+	SoftForkLockedIn
+	// SoftForkActive means the deployment's consensus rules are enforced
+	// from the activation height onwards. Buried deployments report this
+	// status as well (since they are always-active).
+	SoftForkActive
+	// SoftForkFailed means the deployment did not reach the signaling
+	// threshold before its timeout. Terminal — the state machine does not
+	// recover from this.
+	SoftForkFailed
+)
+
+// String returns the BIP9 status string ("defined", "started", "locked_in",
+// "active", "failed", or "unknown") matching bitcoind's getdeploymentinfo
+// output.
+func (s SoftForkStatus) String() string {
+	switch s {
+	case SoftForkDefined:
+		return "defined"
+	case SoftForkStarted:
+		return "started"
+	case SoftForkLockedIn:
+		return "locked_in"
+	case SoftForkActive:
+		return "active"
+	case SoftForkFailed:
+		return "failed"
+	default:
+		return "unknown"
+	}
+}
+
+// parseSoftForkStatus maps a getdeploymentinfo status string onto the typed
+// enum, returning SoftForkUnknown for unrecognized values.
+func parseSoftForkStatus(s string) SoftForkStatus {
+	switch s {
+	case "defined":
+		return SoftForkDefined
+	case "started":
+		return SoftForkStarted
+	case "locked_in":
+		return SoftForkLockedIn
+	case "active":
+		return SoftForkActive
+	case "failed":
+		return SoftForkFailed
+	default:
+		return SoftForkUnknown
+	}
+}
+
+// ErrUnknownDeployment is returned by DeploymentStatus when the named
+// deployment is not present in bitcoind's getdeploymentinfo response.
+// This is the signal a test should use to t.Skip when a soft-fork specific
+// test is run against a bitcoind binary that doesn't know that deployment
+// (e.g. running an APO test against mainline Core).
+var ErrUnknownDeployment = errors.New("unknown deployment")
 
 // DeploymentInfo is the typed shape of bitcoind's getdeploymentinfo response.
 // It describes the BIP9 deployment state machine evaluated as of a specific
@@ -128,6 +205,81 @@ func VBAlwaysActive(name string) VBParam {
 // -2). Useful for tests that want to verify the soft-fork-disabled path.
 func VBNeverActive(name string) VBParam {
 	return VBParam{Deployment: name, StartTime: -2, Timeout: 0, MinActivationHeight: 0}
+}
+
+// DeploymentStatus returns the typed BIP9 status of a single named deployment.
+// Buried deployments (always-active) report SoftForkActive.
+//
+// Parameters:
+//   - name: deployment name as known to bitcoind (e.g. "testdummy", "taproot",
+//     "anyprevout").
+//
+// Returns:
+//   - SoftForkStatus: the typed status enum
+//   - error: ErrUnknownDeployment (errors.Is compatible) when the deployment
+//     is not in the response; errNotConnected before Start; otherwise the
+//     wrapped RPC or unmarshal error.
+//
+// Example:
+//
+//	status, err := rt.DeploymentStatus("anyprevout")
+//	if errors.Is(err, regtest.ErrUnknownDeployment) {
+//	    t.Skip("bitcoind doesn't expose 'anyprevout'")
+//	}
+//	if status != regtest.SoftForkActive {
+//	    t.Fatalf("expected APO active, got %v", status)
+//	}
+func (r *Regtest) DeploymentStatus(name string) (SoftForkStatus, error) {
+	return r.DeploymentStatusContext(context.Background(), name)
+}
+
+// DeploymentStatusContext is the context-aware variant of DeploymentStatus.
+func (r *Regtest) DeploymentStatusContext(ctx context.Context, name string) (SoftForkStatus, error) {
+	info, err := r.GetDeploymentInfoContext(ctx)
+	if err != nil {
+		return SoftForkUnknown, err
+	}
+	d, ok := info.Deployments[name]
+	if !ok {
+		return SoftForkUnknown, fmt.Errorf("%w: %q", ErrUnknownDeployment, name)
+	}
+	// Buried deployments don't carry a BIP9 sub-object; they're hard-coded
+	// active.
+	if d.BIP9 == nil {
+		if d.Active {
+			return SoftForkActive, nil
+		}
+		return SoftForkUnknown, nil
+	}
+	return parseSoftForkStatus(d.BIP9.Status), nil
+}
+
+// waitForDeployment polls DeploymentStatus at ~100ms intervals until the
+// named deployment reaches target, ctx expires, or the deployment terminates
+// in SoftForkFailed (when target != SoftForkFailed).
+//
+// This is the polling primitive that MineUntilActive (#71) layers on top of.
+// It does not mine blocks — callers are expected to drive chain progress in
+// parallel (or rely on a deployment that activates without further input).
+func (r *Regtest) waitForDeployment(ctx context.Context, name string, target SoftForkStatus) error {
+	const interval = 100 * time.Millisecond
+	for {
+		status, err := r.DeploymentStatusContext(ctx, name)
+		if err != nil {
+			return err
+		}
+		if status == target {
+			return nil
+		}
+		if status == SoftForkFailed && target != SoftForkFailed {
+			return fmt.Errorf("deployment %q reached SoftForkFailed (cannot reach %v)", name, target)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(interval):
+		}
+	}
 }
 
 // renderExtraArgs builds the slice of bitcoind flags to forward on Start.


### PR DESCRIPTION
## Summary

Closes #72. Adds the typed RPC layer for inspecting BIP9 soft-fork state on top of `GetDeploymentInfo` (#69), plus the unexported `waitForDeployment` polling primitive that PR 8 (`MineUntilActive`) and PR 7 (testdummy acceptance) will build on.

## Changes

**`softfork.go`**

- `SoftForkStatus int` enum: `Unknown / Defined / Started / LockedIn / Active / Failed`.
- `String()` and `parseSoftForkStatus()` round-trip the BIP9 status strings bitcoind uses (`"defined"`, `"started"`, `"locked_in"`, `"active"`, `"failed"`).
- `ErrUnknownDeployment` sentinel (errors.Is compatible) — the canonical signal a soft-fork test should use to `t.Skip` when running against a bitcoind binary that doesn't know about the deployment (e.g. APO test against mainline Core).
- `DeploymentStatus(name)` / `...Context` wraps `GetDeploymentInfo`. Buried (always-active) deployments map to `SoftForkActive`. Missing names return `ErrUnknownDeployment`.
- `(r *Regtest) waitForDeployment(ctx, name, target)` — unexported polling helper at ~100ms intervals. Returns nil on target match, ctx error on cancel, and a clear error if the deployment terminates in `SoftForkFailed` when `target != Failed`.

**Tests**

- `Test_SoftForkStatus_String`: pure unit test of the round-trip between enum values and BIP9 strings.
- `TestRPC_DeploymentStatus_Taproot`: default regtest → `SoftForkActive`.
- `TestRPC_DeploymentStatus_Unknown`: unrecognized name → `errors.Is(err, ErrUnknownDeployment)`.
- `TestRPC_WaitForDeployment_AlreadyActive`: target=Active on taproot returns immediately.
- `TestRPC_WaitForDeployment_Cancellation`: target=Defined on already-Active taproot surfaces `ctx.Err()` within deadline.
- `Test_RPCMethods_BeforeStart` extended with `DeploymentStatus`.

## Test plan

- [x] `make ai-check` clean
- [x] `Test_SoftForkStatus_String` (5 subtests) PASS
- [x] `TestRPC_DeploymentStatus_Taproot` PASS (3.72s)
- [x] `TestRPC_DeploymentStatus_Unknown` PASS (3.73s)
- [x] `TestRPC_WaitForDeployment_AlreadyActive` PASS (3.73s)
- [x] `TestRPC_WaitForDeployment_Cancellation` PASS (4.03s)
- [x] `Test_RPCMethods_BeforeStart/DeploymentStatus` PASS

## Notes

PR 4b/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Builds on #66/#68/#77/#69/#67/#73. Unblocks PR 8 (#71 `MineUntilActive`) and PR 7 (#81 testdummy acceptance test).