### PR TITLE
[Phase 5.C.1] TestMempoolAccept wrapper

### DIFF
--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -704,6 +705,157 @@ func TestRPC_ChainState(t *testing.T) {
 	}
 	if activeCount != 1 {
 		t.Errorf("expected exactly 1 active tip on linear chain, got %d (tips=%+v)", activeCount, tips)
+	}
+}
+
+// TestRPC_TestMempoolAccept_Valid asks bitcoind to validate a freshly-signed
+// (but unbroadcast) tx. Allowed must be true and Fees must be populated.
+func TestRPC_TestMempoolAccept_Valid(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(userWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(userWallet)
+
+	fromAddr, err := rt.GenerateBech32(userWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32 from: %v", err)
+	}
+	toAddr, err := rt.GenerateBech32(userWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32 to: %v", err)
+	}
+	if err := rt.Warp(101, fromAddr); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Build a skeleton tx with just the destination output; let
+	// fundrawtransaction pick a mature UTXO from the wallet and add change.
+	skelRaw, err := rt.rawRPC(ctx, "createrawtransaction",
+		[]any{},
+		map[string]any{toAddr: 0.5},
+	)
+	if err != nil {
+		t.Fatalf("createrawtransaction: %v", err)
+	}
+	var skelHex string
+	if err := json.Unmarshal(skelRaw, &skelHex); err != nil {
+		t.Fatalf("unmarshal skeleton: %v", err)
+	}
+
+	fundedRaw, err := rt.rawRPC(ctx, "fundrawtransaction", skelHex)
+	if err != nil {
+		t.Fatalf("fundrawtransaction: %v", err)
+	}
+	var funded struct {
+		Hex string `json:"hex"`
+	}
+	if err := json.Unmarshal(fundedRaw, &funded); err != nil {
+		t.Fatalf("unmarshal funded: %v", err)
+	}
+	rawBytes, err := hex.DecodeString(funded.Hex)
+	if err != nil {
+		t.Fatalf("decode funded hex: %v", err)
+	}
+	unsignedTx := wire.NewMsgTx(2)
+	if err := unsignedTx.Deserialize(bytes.NewReader(rawBytes)); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+
+	signedTx, err := rt.SignRawTransactionWithWallet(unsignedTx)
+	if err != nil {
+		t.Fatalf("SignRawTransactionWithWallet: %v", err)
+	}
+
+	results, err := rt.TestMempoolAccept(signedTx)
+	if err != nil {
+		t.Fatalf("TestMempoolAccept: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Allowed {
+		t.Fatalf("expected Allowed=true, got reject reason %q", r.RejectReason)
+	}
+	if r.TxID == "" {
+		t.Error("TxID empty")
+	}
+	if r.VSize <= 0 {
+		t.Errorf("VSize = %d, want > 0", r.VSize)
+	}
+	if r.Fees == nil {
+		t.Error("Fees nil for Allowed tx")
+	} else if r.Fees.Base <= 0 {
+		t.Errorf("Fees.Base = %d, want > 0", r.Fees.Base)
+	}
+}
+
+// TestRPC_TestMempoolAccept_Invalid verifies the rejection path: a tx whose
+// inputs reference a nonexistent prevout must be rejected with a populated
+// RejectReason.
+func TestRPC_TestMempoolAccept_Invalid(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	// Build a tx with a clearly nonexistent prevout (all-zero hash, vout 0)
+	// and a single OP_RETURN output to keep parsing simple.
+	bogus := wire.NewMsgTx(2)
+	bogus.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0},
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	// Minimal OP_RETURN output: scriptPubKey = 0x6a (OP_RETURN).
+	bogus.AddTxOut(wire.NewTxOut(0, []byte{0x6a}))
+
+	results, err := rt.TestMempoolAccept(bogus)
+	if err != nil {
+		t.Fatalf("TestMempoolAccept: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.Allowed {
+		t.Errorf("expected Allowed=false for bogus tx, got Allowed=true")
+	}
+	if r.RejectReason == "" {
+		t.Error("expected non-empty RejectReason for rejected tx")
+	}
+	t.Logf("bogus tx rejected with reason: %s", r.RejectReason)
+}
+
+// TestRPC_TestMempoolAccept_Empty pins the validation contract that calling
+// TestMempoolAccept with no transactions returns an error.
+func TestRPC_TestMempoolAccept_Empty(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if _, err := rt.TestMempoolAccept(); err == nil {
+		t.Fatal("expected error on empty input, got nil")
 	}
 }
 

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // testdummyConfig builds a Config that points bitcoind at a fresh data dir
@@ -409,6 +410,13 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 		{"GetChainTips", func() error { _, err := rt.GetChainTips(); return err }},
 		{"GetDeploymentInfo", func() error { _, err := rt.GetDeploymentInfo(); return err }},
 		{"DeploymentStatus", func() error { _, err := rt.DeploymentStatus("taproot"); return err }},
+		{"TestMempoolAccept", func() error {
+			tx := wire.NewMsgTx(2)
+			tx.AddTxIn(&wire.TxIn{})
+			tx.AddTxOut(wire.NewTxOut(0, []byte{0x6a}))
+			_, err := rt.TestMempoolAccept(tx)
+			return err
+		}},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {

--- a/tx.go
+++ b/tx.go
@@ -283,3 +283,110 @@ func (r *Regtest) BroadcastTransactionContext(ctx context.Context, tx *wire.MsgT
 	}
 	return txid, nil
 }
+
+// MempoolAcceptResult is the per-tx result of TestMempoolAccept.
+type MempoolAcceptResult struct {
+	// TxID is the transaction hash in hex.
+	TxID string
+	// Wtxid is the witness transaction hash in hex.
+	Wtxid string
+	// Allowed reports whether the tx would enter the mempool. False means
+	// either policy or consensus rejection — see RejectReason.
+	Allowed bool
+	// VSize is the virtual transaction size in vbytes (set when Allowed is true).
+	VSize int64
+	// Fees carries fee metadata when Allowed is true; nil when rejected.
+	Fees *MempoolAcceptFees
+	// RejectReason is bitcoind's policy or consensus reject string. Empty when
+	// Allowed is true. This is the single most useful field for soft-fork
+	// debugging — it distinguishes policy issues like "non-mandatory-script-
+	// verify-flag" from consensus issues like "bad-txns-inputs-missingorspent".
+	RejectReason string
+	// PackageError is set when a multi-tx submission fails package validation.
+	PackageError string
+}
+
+// MempoolAcceptFees is the fee section of MempoolAcceptResult.
+type MempoolAcceptFees struct {
+	// Base is the absolute transaction fee.
+	Base btcutil.Amount
+	// EffectiveFeeRate is the effective fee rate (BTC per KvB), accounting
+	// for prioritisetransaction or package-feerate adjustments. Bitcoin
+	// Core 25+; zero on older nodes.
+	EffectiveFeeRate float64
+	// EffectiveIncludes lists wtxids whose fees and vsizes contribute to
+	// EffectiveFeeRate. Bitcoin Core 25+; nil on older nodes.
+	EffectiveIncludes []string
+}
+
+// TestMempoolAccept asks bitcoind whether the given transactions would be
+// accepted to the mempool, without broadcasting. The single most useful RPC
+// for soft-fork debugging — RejectReason distinguishes policy from consensus
+// rejections, so a test can tell "my APO sig is non-standard" apart from
+// "my APO sig is consensus-invalid".
+//
+// At least one tx is required. When multiple txs are passed, parents must
+// come before children and package policies apply (Bitcoin Core 24+).
+//
+// Parameters:
+//   - txs: one or more *wire.MsgTx to test (at least one)
+//
+// Returns:
+//   - []MempoolAcceptResult: one result per input tx, in the same order
+//   - error: errNotConnected before Start; validation error for empty input;
+//     otherwise wrapped RPC error.
+//
+// Example:
+//
+//	res, err := rt.TestMempoolAccept(myTx)
+//	if err != nil {
+//	    return err
+//	}
+//	if !res[0].Allowed {
+//	    t.Fatalf("rejected: %s", res[0].RejectReason)
+//	}
+func (r *Regtest) TestMempoolAccept(txs ...*wire.MsgTx) ([]MempoolAcceptResult, error) {
+	return r.TestMempoolAcceptContext(context.Background(), txs...)
+}
+
+// TestMempoolAcceptContext is the context-aware variant of TestMempoolAccept.
+func (r *Regtest) TestMempoolAcceptContext(ctx context.Context, txs ...*wire.MsgTx) ([]MempoolAcceptResult, error) {
+	if len(txs) == 0 {
+		return nil, fmt.Errorf("at least one tx required")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	// maxFeeRate=0 disables btcd's client-side fee-rate cap so regtest tests
+	// see the same accept/reject decision bitcoind would make on its own.
+	raw, err := runWithContext(ctx, func() ([]*btcjson.TestMempoolAcceptResult, error) {
+		return client.TestMempoolAccept(txs, 0)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("testmempoolaccept: %w", err)
+	}
+	out := make([]MempoolAcceptResult, len(raw))
+	for i, e := range raw {
+		out[i] = MempoolAcceptResult{
+			TxID:         e.Txid,
+			Wtxid:        e.Wtxid,
+			Allowed:      e.Allowed,
+			VSize:        int64(e.Vsize),
+			RejectReason: e.RejectReason,
+			PackageError: e.PackageError,
+		}
+		if e.Fees != nil {
+			base, err := btcutil.NewAmount(e.Fees.Base)
+			if err != nil {
+				return nil, fmt.Errorf("converting fee base %v: %w", e.Fees.Base, err)
+			}
+			out[i].Fees = &MempoolAcceptFees{
+				Base:              base,
+				EffectiveFeeRate:  e.Fees.EffectiveFeeRate,
+				EffectiveIncludes: append([]string(nil), e.Fees.EffectiveIncludes...),
+			}
+		}
+	}
+	return out, nil
+}


### PR DESCRIPTION
## Summary

Closes #74. Adds the typed `testmempoolaccept` wrapper — the single most useful RPC for soft-fork debugging. `RejectReason` distinguishes policy from consensus rejections, so a soft-fork test can tell "my APO sig is non-standard policy-wise" apart from "my APO sig is consensus-invalid".

## Changes

**`tx.go`**

- `MempoolAcceptResult` (TxID, Wtxid, Allowed, VSize, Fees, RejectReason, PackageError).
- `MempoolAcceptFees` (Base as `btcutil.Amount`, EffectiveFeeRate, EffectiveIncludes — the latter two are Core 25+).
- `TestMempoolAccept(txs ...*wire.MsgTx)` / `...Context` wraps btcsuite's typed `TestMempoolAccept` via `runWithContext`. `maxFeeRate=0` disables btcd's client-side fee-rate cap so regtest tests see the same accept/reject decision bitcoind would make on its own.
- Empty-input validation returns an error before issuing the RPC.
- `Fees.Base` is converted from BTC float to `btcutil.Amount` via `btcutil.NewAmount` for consistency with the rest of the package.

## Tests

- `TestRPC_TestMempoolAccept_Valid`: builds a freshly-signed (but unbroadcast) tx via `createrawtransaction` + `fundrawtransaction` + `SignRawTransactionWithWallet`, asserts `Allowed=true` with populated `Fees` and `VSize`. Uses `fundrawtransaction` so the wallet picks mature coinbase UTXOs (avoids `bad-txns-premature-spend-of-coinbase`).
- `TestRPC_TestMempoolAccept_Invalid`: a `*wire.MsgTx` referencing a nonexistent (all-zero) prevout — asserts `Allowed=false` with a populated `RejectReason`.
- `TestRPC_TestMempoolAccept_Empty`: zero txs returns a validation error.
- `Test_RPCMethods_BeforeStart` extended with `TestMempoolAccept`.

## Test plan

- [x] `make ai-check` clean
- [x] `TestRPC_TestMempoolAccept_Valid` PASS (4.28s)
- [x] `TestRPC_TestMempoolAccept_Invalid` PASS (3.72s) — reject reason `tx-size-small`
- [x] `TestRPC_TestMempoolAccept_Empty` PASS (3.71s)
- [x] `Test_RPCMethods_BeforeStart/TestMempoolAccept` PASS

## Notes

PR 5/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Independent of subsequent PRs — anything in Phase 5 that wants to assert "this tx would be rejected with reason X" can now use this.