### PR TITLE
[Phase 5.D.1] Reorg primitives: InvalidateBlock, ReconsiderBlock, PreciousBlock

### DIFF
--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -708,6 +708,129 @@ func TestRPC_ChainState(t *testing.T) {
 	}
 }
 
+// TestRPC_Reorg_InvalidateReconsider exercises the InvalidateBlock and
+// ReconsiderBlock primitives. After mining 5 blocks, invalidating the tip
+// must drop the chain by one; reconsidering it must restore the original
+// tip.
+func TestRPC_Reorg_InvalidateReconsider(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(minerWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(minerWallet)
+	addr, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+	if err := rt.Warp(5, addr); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	beforeHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+	tip, err := rt.GetBestBlockHash()
+	if err != nil {
+		t.Fatalf("GetBestBlockHash: %v", err)
+	}
+
+	if err := rt.InvalidateBlock(tip); err != nil {
+		t.Fatalf("InvalidateBlock: %v", err)
+	}
+	afterHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount post-invalidate: %v", err)
+	}
+	if afterHeight != beforeHeight-1 {
+		t.Errorf("height after invalidate = %d, want %d", afterHeight, beforeHeight-1)
+	}
+
+	if err := rt.ReconsiderBlock(tip); err != nil {
+		t.Fatalf("ReconsiderBlock: %v", err)
+	}
+	restoredHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount post-reconsider: %v", err)
+	}
+	if restoredHeight != beforeHeight {
+		t.Errorf("height after reconsider = %d, want %d", restoredHeight, beforeHeight)
+	}
+	restoredTip, err := rt.GetBestBlockHash()
+	if err != nil {
+		t.Fatalf("GetBestBlockHash post-reconsider: %v", err)
+	}
+	if !restoredTip.IsEqual(tip) {
+		t.Errorf("tip after reconsider = %s, want %s", restoredTip, tip)
+	}
+}
+
+// TestRPC_Reorg_PreciousBlock_Linear pins that PreciousBlock against the
+// current tip on a linear chain is a harmless no-op (no fork to choose
+// between). Full fork-choice exercise lands in PR 11 (#80) once multi-node
+// P2P is in place.
+func TestRPC_Reorg_PreciousBlock_Linear(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(minerWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(minerWallet)
+	addr, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+	if err := rt.Warp(3, addr); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	tip, err := rt.GetBestBlockHash()
+	if err != nil {
+		t.Fatalf("GetBestBlockHash: %v", err)
+	}
+	if err := rt.PreciousBlock(tip); err != nil {
+		t.Fatalf("PreciousBlock(tip) on linear chain: %v", err)
+	}
+}
+
+// TestRPC_Reorg_NilHash pins the validation contract for the three reorg
+// primitives.
+func TestRPC_Reorg_NilHash(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.InvalidateBlock(nil); err == nil {
+		t.Error("InvalidateBlock(nil) should error")
+	}
+	if err := rt.ReconsiderBlock(nil); err == nil {
+		t.Error("ReconsiderBlock(nil) should error")
+	}
+	if err := rt.PreciousBlock(nil); err == nil {
+		t.Error("PreciousBlock(nil) should error")
+	}
+}
+
 // TestRPC_TestMempoolAccept_Valid asks bitcoind to validate a freshly-signed
 // (but unbroadcast) tx. Allowed must be true and Fees must be populated.
 func TestRPC_TestMempoolAccept_Valid(t *testing.T) {

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -417,6 +417,9 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 			_, err := rt.TestMempoolAccept(tx)
 			return err
 		}},
+		{"InvalidateBlock", func() error { return rt.InvalidateBlock(&chainhash.Hash{}) }},
+		{"ReconsiderBlock", func() error { return rt.ReconsiderBlock(&chainhash.Hash{}) }},
+		{"PreciousBlock", func() error { return rt.PreciousBlock(&chainhash.Hash{}) }},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {

--- a/reorg.go
+++ b/reorg.go
@@ -1,0 +1,130 @@
+package regtest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// InvalidateBlock marks a block as invalid, rolling the chain back past it.
+// On a linear chain this reduces the tip height by however many blocks sit
+// at or above the invalidated one. The block (and its descendants) remain
+// known to the node and can be reactivated with ReconsiderBlock.
+//
+// Combined with ReconsiderBlock and PreciousBlock this is the core primitive
+// for scripted reorgs — required by soft-fork tests that need to verify a
+// signature scheme survives the funding UTXO changing identity (eltoo's
+// SIGHASH_ANYPREVOUT rebind property, for example).
+//
+// Parameters:
+//   - hash: block hash (must be non-nil)
+//
+// Returns:
+//   - error: validation error for nil hash; errNotConnected before Start;
+//     otherwise wrapped RPC error.
+//
+// Example:
+//
+//	tip, _ := rt.GetBestBlockHash()
+//	rt.InvalidateBlock(tip) // chain rolls back by one
+func (r *Regtest) InvalidateBlock(hash *chainhash.Hash) error {
+	return r.InvalidateBlockContext(context.Background(), hash)
+}
+
+// InvalidateBlockContext is the context-aware variant of InvalidateBlock.
+func (r *Regtest) InvalidateBlockContext(ctx context.Context, hash *chainhash.Hash) error {
+	if hash == nil {
+		return fmt.Errorf("hash must not be nil")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return err
+	}
+	_, err = runWithContext(ctx, func() (struct{}, error) {
+		return struct{}{}, client.InvalidateBlock(hash)
+	})
+	if err != nil {
+		return fmt.Errorf("invalidateblock %s: %w", hash, err)
+	}
+	return nil
+}
+
+// ReconsiderBlock removes the invalid mark from a block previously marked via
+// InvalidateBlock, allowing the node to reactivate it (and its descendants)
+// if doing so would extend the most-work chain.
+//
+// Parameters:
+//   - hash: block hash (must be non-nil)
+//
+// Returns:
+//   - error: validation error for nil hash; errNotConnected before Start;
+//     otherwise wrapped RPC error.
+//
+// Example:
+//
+//	rt.InvalidateBlock(tip)
+//	// ... do something with the rolled-back chain
+//	rt.ReconsiderBlock(tip) // restore
+func (r *Regtest) ReconsiderBlock(hash *chainhash.Hash) error {
+	return r.ReconsiderBlockContext(context.Background(), hash)
+}
+
+// ReconsiderBlockContext is the context-aware variant of ReconsiderBlock.
+func (r *Regtest) ReconsiderBlockContext(ctx context.Context, hash *chainhash.Hash) error {
+	if hash == nil {
+		return fmt.Errorf("hash must not be nil")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return err
+	}
+	_, err = runWithContext(ctx, func() (struct{}, error) {
+		return struct{}{}, client.ReconsiderBlock(hash)
+	})
+	if err != nil {
+		return fmt.Errorf("reconsiderblock %s: %w", hash, err)
+	}
+	return nil
+}
+
+// PreciousBlock marks a block as preferred when fork-choice is otherwise a
+// tie — the active chain switches to whichever fork includes the precious
+// block, even if its work is equal to the current tip's. Useful for scripted
+// reorg tests where two equally-long chains compete and you want to force
+// one to win.
+//
+// btcsuite has no typed wrapper for preciousblock; this method uses rawRPC.
+//
+// Parameters:
+//   - hash: block hash (must be non-nil)
+//
+// Returns:
+//   - error: validation error for nil hash; errNotConnected before Start;
+//     otherwise wrapped RPC error.
+func (r *Regtest) PreciousBlock(hash *chainhash.Hash) error {
+	return r.PreciousBlockContext(context.Background(), hash)
+}
+
+// PreciousBlockContext is the context-aware variant of PreciousBlock.
+func (r *Regtest) PreciousBlockContext(ctx context.Context, hash *chainhash.Hash) error {
+	if hash == nil {
+		return fmt.Errorf("hash must not be nil")
+	}
+	// preciousblock takes a hex-encoded block hash. The hash bytes need
+	// big-endian (display) ordering, which chainhash.Hash.String() provides.
+	raw, err := r.rawRPC(ctx, "preciousblock", hash.String())
+	if err != nil {
+		return fmt.Errorf("preciousblock %s: %w", hash, err)
+	}
+	// preciousblock returns null on success; tolerate either null or an
+	// empty JSON value.
+	if len(raw) > 0 && string(raw) != "null" {
+		var ignored json.RawMessage
+		if err := json.Unmarshal(raw, &ignored); err != nil {
+			return fmt.Errorf("preciousblock unexpected response: %s", raw)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Closes #78. Adds the three RPC wrappers for scripted reorg testing in a new `reorg.go`. These are the consensus-side primitives the eltoo / APO roadmap relies on — verifying that a `SIGHASH_ANYPREVOUT` signature survives the funding UTXO changing identity requires being able to roll the chain back past that funding tx and reattach it on a fork.

## Changes

**`reorg.go`** (new file)

- `InvalidateBlock(hash)` / `...Context`: typed btcsuite via `runWithContext`. Rolls the chain back past the named block.
- `ReconsiderBlock(hash)` / `...Context`: typed btcsuite via `runWithContext`. Reactivates a previously-invalidated block (and its descendants).
- `PreciousBlock(hash)` / `...Context`: via `rawRPC` because btcsuite has no typed wrapper. Lets a tied-work fork beat the current tip.
- All three reject nil hash with a clear error rather than panicking.

**Tests**

- `TestRPC_Reorg_InvalidateReconsider`: `Warp(5)`, invalidate tip → height drops by 1; reconsider → height + tip restored exactly to pre-invalidate state.
- `TestRPC_Reorg_PreciousBlock_Linear`: `PreciousBlock` against the current tip on a linear chain is a harmless no-op. Full fork-choice test waits for PR 10/11 (multi-node P2P + two-node reorg example) where a competing tip can actually exist.
- `TestRPC_Reorg_NilHash`: pins the validation contract for all three.
- `Test_RPCMethods_BeforeStart` extended with all three wrappers.

## Test plan

- [x] `make ai-check` clean
- [x] `TestRPC_Reorg_InvalidateReconsider` PASS (3.94s)
- [x] `TestRPC_Reorg_PreciousBlock_Linear` PASS (3.91s)
- [x] `TestRPC_Reorg_NilHash` PASS (3.72s)
- [x] All three new BeforeStart subtests PASS

## Notes

PR 6/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). Closes Phase 5.0's Tier D foundation. Next up: PR 7 (#81 testdummy acceptance test) which closes Phase 5.0.