### PR TITLE
[Phase 5.B.1 + 5.B.2] Mining helpers: MineToHeight + MineUntilActive

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -2,9 +2,98 @@ package regtest
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
+
+// TestMineUntilActive_Testdummy is the streamlined version of
+// TestExampleActivateTestdummy: same harness, same testdummy deployment,
+// but the mining loop is replaced with a single MineUntilActive call.
+// Pins that the helper composes correctly with VBParams + WarpContext +
+// DeploymentStatusContext.
+func TestMineUntilActive_Testdummy(t *testing.T) {
+	rt, err := New(testdummyConfig(t, 19900))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet("miner"); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	miner, err := rt.GenerateBech32("miner")
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	mined, err := rt.MineUntilActiveContext(ctx, "testdummy", miner, 2000)
+	if err != nil {
+		t.Fatalf("MineUntilActive: %v", err)
+	}
+	t.Logf("testdummy activated after %d blocks", mined)
+
+	status, err := rt.DeploymentStatus("testdummy")
+	if err != nil {
+		t.Fatalf("DeploymentStatus: %v", err)
+	}
+	if status != SoftForkActive {
+		t.Errorf("post-MineUntilActive status = %v, want SoftForkActive", status)
+	}
+}
+
+// TestMineUntilActive_UnknownDeployment pins the early-exit contract:
+// MineUntilActive returns ErrUnknownDeployment without mining a single
+// block when the deployment name isn't known to bitcoind. This is the
+// signal a soft-fork-specific test should use to t.Skip cleanly when
+// run against mainline Core.
+func TestMineUntilActive_UnknownDeployment(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet("miner"); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	miner, err := rt.GenerateBech32("miner")
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+
+	startHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+
+	mined, err := rt.MineUntilActive("does-not-exist", miner, 1000)
+	if err == nil {
+		t.Fatal("expected ErrUnknownDeployment, got nil")
+	}
+	if !errors.Is(err, ErrUnknownDeployment) {
+		t.Errorf("expected errors.Is(err, ErrUnknownDeployment), got %v", err)
+	}
+	if mined != 0 {
+		t.Errorf("expected 0 blocks mined for unknown deployment, got %d", mined)
+	}
+	endHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+	if endHeight != startHeight {
+		t.Errorf("unknown-deployment path mined blocks: %d -> %d", startHeight, endHeight)
+	}
+}
 
 // TestExampleActivateTestdummy is a narrated end-to-end example of
 // activating Bitcoin Core's "testdummy" BIP9 soft-fork deployment from

--- a/mining.go
+++ b/mining.go
@@ -65,3 +65,133 @@ func (r *Regtest) WarpContext(ctx context.Context, blocks int64, miner string) e
 	}
 	return nil
 }
+
+// MineToHeight advances the chain to a specific block height. It reads the
+// current height and mines (target - current) blocks via Warp. Idempotent:
+// if target is at or below the current height, MineToHeight is a no-op.
+//
+// Parameters:
+//   - target: target block height (must be >= 0)
+//   - miner: Bitcoin address to receive coinbase rewards
+//
+// Returns:
+//   - error: validation error for negative target or empty miner;
+//     errNotConnected before Start; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	if err := rt.MineToHeight(101, addr); err != nil { ... } // mature coinbase
+//	if err := rt.MineToHeight(101, addr); err != nil { ... } // no-op
+func (r *Regtest) MineToHeight(target int64, miner string) error {
+	return r.MineToHeightContext(context.Background(), target, miner)
+}
+
+// MineToHeightContext is the context-aware variant of MineToHeight.
+func (r *Regtest) MineToHeightContext(ctx context.Context, target int64, miner string) error {
+	if target < 0 {
+		return fmt.Errorf("target must be >= 0, got %d", target)
+	}
+	if miner == "" {
+		return fmt.Errorf("miner must be provided")
+	}
+	current, err := r.GetBlockCountContext(ctx)
+	if err != nil {
+		return fmt.Errorf("get current height: %w", err)
+	}
+	delta := target - current
+	if delta <= 0 {
+		return nil
+	}
+	return r.WarpContext(ctx, delta, miner)
+}
+
+// MineUntilActive mines blocks one retarget window at a time until the
+// named BIP9 deployment reaches SoftForkActive. Returns the number of
+// blocks mined. Polls DeploymentStatus after each window so the BIP9
+// state machine has a chance to advance.
+//
+// This is the canonical "set up a soft-fork for testing" primitive. For
+// the typical regtest deployment with start_time=0 and a far-future
+// timeout, activation completes in ~3 retarget windows (~432 blocks)
+// because Bitcoin Core's default block-version policy signals for all
+// currently-STARTED deployments.
+//
+// Parameters:
+//   - deployment: deployment name as known to bitcoind
+//   - miner: Bitcoin address to receive coinbase rewards
+//   - maxBlocks: hard cap on blocks mined (must be > 0). Activation
+//     within fewer than maxBlocks blocks is the success path; reaching
+//     maxBlocks without activation is an error reporting the final
+//     status.
+//
+// Returns:
+//   - int64: blocks actually mined
+//   - error: validation error for empty miner or zero maxBlocks;
+//     ErrUnknownDeployment when the deployment name isn't known to
+//     bitcoind; SoftForkFailed-related error if the deployment fails;
+//     wrapped RPC error otherwise.
+//
+// Example:
+//
+//	mined, err := rt.MineUntilActive("testdummy", addr, 2000)
+//	if err != nil { return err }
+//	fmt.Printf("activated after %d blocks\n", mined)
+func (r *Regtest) MineUntilActive(deployment, miner string, maxBlocks int64) (int64, error) {
+	return r.MineUntilActiveContext(context.Background(), deployment, miner, maxBlocks)
+}
+
+// MineUntilActiveContext is the context-aware variant of MineUntilActive.
+func (r *Regtest) MineUntilActiveContext(ctx context.Context, deployment, miner string, maxBlocks int64) (int64, error) {
+	if miner == "" {
+		return 0, fmt.Errorf("miner must be provided")
+	}
+	if maxBlocks <= 0 {
+		return 0, fmt.Errorf("maxBlocks must be > 0, got %d", maxBlocks)
+	}
+
+	// Validate the deployment is known up front so callers get a clean
+	// ErrUnknownDeployment instead of mining 1500 blocks for nothing.
+	status, err := r.DeploymentStatusContext(ctx, deployment)
+	if err != nil {
+		return 0, err
+	}
+	if status == SoftForkActive {
+		return 0, nil
+	}
+	if status == SoftForkFailed {
+		return 0, fmt.Errorf("deployment %q is in SoftForkFailed (cannot reach Active)", deployment)
+	}
+
+	// Mine in retarget-window-sized chunks (the natural cadence at which
+	// the BIP9 state machine advances on regtest). The last chunk is
+	// truncated so we never overshoot maxBlocks.
+	const window = int64(144)
+	var mined int64
+	for mined < maxBlocks {
+		chunk := window
+		if remaining := maxBlocks - mined; remaining < chunk {
+			chunk = remaining
+		}
+		if err := r.WarpContext(ctx, chunk, miner); err != nil {
+			return mined, fmt.Errorf("mine chunk: %w", err)
+		}
+		mined += chunk
+
+		status, err := r.DeploymentStatusContext(ctx, deployment)
+		if err != nil {
+			return mined, err
+		}
+		if status == SoftForkActive {
+			return mined, nil
+		}
+		if status == SoftForkFailed {
+			return mined, fmt.Errorf("deployment %q reached SoftForkFailed after %d blocks", deployment, mined)
+		}
+	}
+
+	final, fErr := r.DeploymentStatusContext(ctx, deployment)
+	if fErr != nil {
+		return mined, fmt.Errorf("deployment %q did not reach Active within %d blocks (status check after maxBlocks failed: %w)", deployment, maxBlocks, fErr)
+	}
+	return mined, fmt.Errorf("deployment %q did not reach Active within %d blocks (final status: %s)", deployment, maxBlocks, final)
+}

--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -708,6 +708,67 @@ func TestRPC_ChainState(t *testing.T) {
 	}
 }
 
+// TestRPC_MineToHeight verifies the idempotent target-height helper.
+func TestRPC_MineToHeight(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(minerWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(minerWallet)
+	addr, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+
+	if err := rt.MineToHeight(20, addr); err != nil {
+		t.Fatalf("MineToHeight(20): %v", err)
+	}
+	h, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+	if h != 20 {
+		t.Errorf("after MineToHeight(20), height = %d", h)
+	}
+
+	// Idempotent: second call mines nothing.
+	if err := rt.MineToHeight(20, addr); err != nil {
+		t.Fatalf("MineToHeight(20) idempotent: %v", err)
+	}
+	h2, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+	if h2 != 20 {
+		t.Errorf("idempotent call advanced height: %d -> %d", h, h2)
+	}
+
+	// target < current is also a no-op.
+	if err := rt.MineToHeight(5, addr); err != nil {
+		t.Fatalf("MineToHeight(5) when at 20: %v", err)
+	}
+	h3, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+	if h3 != 20 {
+		t.Errorf("backward target rolled chain: %d -> %d", h, h3)
+	}
+
+	// Negative target → validation error.
+	if err := rt.MineToHeight(-1, addr); err == nil {
+		t.Error("MineToHeight(-1) should error")
+	}
+}
+
 // TestRPC_Reorg_InvalidateReconsider exercises the InvalidateBlock and
 // ReconsiderBlock primitives. After mining 5 blocks, invalidating the tip
 // must drop the chain by one; reconsidering it must restore the original

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -420,6 +420,13 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 		{"InvalidateBlock", func() error { return rt.InvalidateBlock(&chainhash.Hash{}) }},
 		{"ReconsiderBlock", func() error { return rt.ReconsiderBlock(&chainhash.Hash{}) }},
 		{"PreciousBlock", func() error { return rt.PreciousBlock(&chainhash.Hash{}) }},
+		{"MineToHeight", func() error {
+			return rt.MineToHeight(1, "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl")
+		}},
+		{"MineUntilActive", func() error {
+			_, err := rt.MineUntilActive("testdummy", "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl", 100)
+			return err
+		}},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #70 and #71. Adds the two mining helpers that compose with the soft-fork harness from Phase 5.0.

## Changes

**`mining.go`**

- `MineToHeight(target, miner)` / `...Context`: reads current height and mines `target - current` blocks via Warp. Idempotent — `target <= current` is a no-op (the chain never regresses). Negative target is a validation error.
- `MineUntilActive(deployment, miner, maxBlocks)` / `...Context`: the canonical "set up a soft-fork for testing" primitive. Mines in retarget-window-sized chunks (144 blocks — the natural BIP9 cadence on regtest) and polls `DeploymentStatus` after each. Returns the number of blocks actually mined. Validates the deployment up front so an unknown name surfaces `ErrUnknownDeployment` without mining anything. Errors cleanly on `SoftForkFailed` and on hitting `maxBlocks` without activation, with the final status included in the error message.

## Tests

- `TestRPC_MineToHeight`: covers the happy path, idempotency, target < current (no-op), and negative-target validation.
- `TestMineUntilActive_Testdummy` (port 19900): the streamlined version of the testdummy acceptance test (#81) — the explicit mining loop is replaced by a single `MineUntilActive` call. Pins that the helper composes correctly with `testdummyConfig`.
- `TestMineUntilActive_UnknownDeployment`: pins the early-exit contract. An unknown deployment name returns `ErrUnknownDeployment` via `errors.Is` without mining a single block (verified via height delta).
- `Test_RPCMethods_BeforeStart` extended with both helpers.

## Test plan

- [x] `make ai-check` clean
- [x] `TestRPC_MineToHeight` PASS (3.97s)
- [x] `TestMineUntilActive_Testdummy` PASS (5.79s) — same fast-activation profile as the testdummy walkthrough
- [x] `TestMineUntilActive_UnknownDeployment` PASS (3.91s)
- [x] All BeforeStart subtests PASS

## Notes

PR 8/12 in the [Phase 5 soft-fork roadmap](https://github.com/neverDefined/go-regtest/issues/83). First piece of **Phase 5.1 — Expansion**. Independent of subsequent PRs.