### PR TITLE
[Phase 5.C.2 + 5.C.3] Block template + raw tx wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ type Config struct {
 
 **Addresses:** `GenerateBech32(label)`, `GenerateBech32m(label)`
 
-**Mining:** `Warp(blocks, address)`
+**Mining:** `Warp(blocks, address)`, `MineToHeight(target, address)`, `MineUntilActive(deployment, address, maxBlocks)`, `GetBlockTemplate(req)`, `SubmitBlock(block)`
 
-**Transactions:** `SendToAddress(address, sats)`, `GetTxOut(txid, vout, includeMempool)`, `ScanTxOutSetForAddress(address)`, `SignRawTransactionWithWallet(tx)`, `BroadcastTransaction(tx)`
+**Transactions:** `SendToAddress(address, sats)`, `GetTxOut(txid, vout, includeMempool)`, `ScanTxOutSetForAddress(address)`, `SignRawTransactionWithWallet(tx)`, `BroadcastTransaction(tx)`, `CreateRawTransaction(inputs, amounts, lockTime)`, `DecodeRawTransaction(tx)`, `DecodeScript(scriptHex)`, `FundRawTransaction(tx, opts)`, `TestMempoolAccept(txs...)`
 
 Every RPC-issuing method also has a `*Context` variant (`StartContext`, `GetBlockCountContext`, `WarpContext`, etc.) that accepts a `context.Context` for timeout and cancellation. The non-`Context` form is a thin `context.Background()` wrapper.
 

--- a/block.go
+++ b/block.go
@@ -1,0 +1,93 @@
+package regtest
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// GetBlockTemplate returns a block template suitable for assembly and
+// submission via SubmitBlock. The "no mempool" path: build a block that
+// includes a target tx directly, bypassing policy checks. Useful for
+// consensus-rule testing where a tx is consensus-valid but policy-rejected
+// even with -acceptnonstdtxn.
+//
+// Parameters:
+//   - req: template request (mode, rules, etc.). Pass &btcjson.TemplateRequest{
+//     Mode: "template", Rules: []string{"segwit"}} for a basic regtest template;
+//     additional rules (e.g. "taproot") may be required to advertise support
+//     for active deployments depending on Core version.
+//
+// Returns:
+//   - *btcjson.GetBlockTemplateResult: previous block hash, target, height,
+//     coinbase value, witness commitment, and the candidate tx list.
+//   - error: errNotConnected before Start; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	tmpl, err := rt.GetBlockTemplate(&btcjson.TemplateRequest{
+//	    Mode: "template", Rules: []string{"segwit"},
+//	})
+//	if err != nil { return err }
+//	fmt.Println("template height:", tmpl.Height)
+func (r *Regtest) GetBlockTemplate(req *btcjson.TemplateRequest) (*btcjson.GetBlockTemplateResult, error) {
+	return r.GetBlockTemplateContext(context.Background(), req)
+}
+
+// GetBlockTemplateContext is the context-aware variant of GetBlockTemplate.
+func (r *Regtest) GetBlockTemplateContext(ctx context.Context, req *btcjson.TemplateRequest) (*btcjson.GetBlockTemplateResult, error) {
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := runWithContext(ctx, func() (*btcjson.GetBlockTemplateResult, error) {
+		return client.GetBlockTemplate(req)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("getblocktemplate: %w", err)
+	}
+	return res, nil
+}
+
+// SubmitBlock submits an assembled block to bitcoind. The companion to
+// GetBlockTemplate for "include this tx in a block without going through the
+// mempool" patterns common in consensus-focused soft-fork tests.
+//
+// Parameters:
+//   - block: the block to submit (must be non-nil). Coinbase, witness
+//     commitment, and proof-of-work must already be valid.
+//
+// Returns:
+//   - error: validation error for nil block; errNotConnected before Start;
+//     otherwise wrapped RPC error including bitcoind's reject reason
+//     ("bad-cb-amount", "high-hash", "block-validation-failed", etc.).
+//
+// Example:
+//
+//	if err := rt.SubmitBlock(myBlock); err != nil {
+//	    return fmt.Errorf("submit: %w", err)
+//	}
+func (r *Regtest) SubmitBlock(block *wire.MsgBlock) error {
+	return r.SubmitBlockContext(context.Background(), block)
+}
+
+// SubmitBlockContext is the context-aware variant of SubmitBlock.
+func (r *Regtest) SubmitBlockContext(ctx context.Context, block *wire.MsgBlock) error {
+	if block == nil {
+		return fmt.Errorf("block must not be nil")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return err
+	}
+	_, err = runWithContext(ctx, func() (struct{}, error) {
+		return struct{}{}, client.SubmitBlock(btcutil.NewBlock(block), nil)
+	})
+	if err != nil {
+		return fmt.Errorf("submitblock: %w", err)
+	}
+	return nil
+}

--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -8,13 +8,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -1211,5 +1215,385 @@ func TestRPC_ChainState_NilHash(t *testing.T) {
 	}
 	if _, err := rt.GetBlockHeader(nil); err == nil {
 		t.Error("GetBlockHeader(nil) should return validation error")
+	}
+}
+
+// assembleTrivialRegtestBlock builds a minimum valid regtest block on top of
+// tmpl: a single coinbase tx paying to OP_TRUE, with the witness commitment
+// the template provided, then brute-force solves the (trivial) regtest PoW.
+// On regtest the difficulty target is essentially MAX_HASH so the loop
+// almost always solves at nonce=0.
+func assembleTrivialRegtestBlock(t *testing.T, tmpl *btcjson.GetBlockTemplateResult) *wire.MsgBlock {
+	t.Helper()
+
+	prev, err := chainhash.NewHashFromStr(tmpl.PreviousHash)
+	if err != nil {
+		t.Fatalf("parse previous hash: %v", err)
+	}
+	bitsU64, err := strconv.ParseUint(tmpl.Bits, 16, 32)
+	if err != nil {
+		t.Fatalf("parse bits %q: %v", tmpl.Bits, err)
+	}
+	bits := uint32(bitsU64)
+	if tmpl.CoinbaseValue == nil {
+		t.Fatalf("template missing CoinbaseValue")
+	}
+
+	// Coinbase scriptSig: BIP34 height + extranonce.
+	cbScript, err := txscript.NewScriptBuilder().
+		AddInt64(tmpl.Height).
+		AddInt64(0).
+		Script()
+	if err != nil {
+		t.Fatalf("build coinbase script: %v", err)
+	}
+	coinbase := wire.NewMsgTx(2)
+	coinbase.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Hash: chainhash.Hash{}, Index: 0xffffffff},
+		SignatureScript:  cbScript,
+		Sequence:         0xffffffff,
+		Witness:          wire.TxWitness{make([]byte, 32)},
+	})
+	coinbase.AddTxOut(wire.NewTxOut(*tmpl.CoinbaseValue, []byte{txscript.OP_TRUE}))
+	if tmpl.DefaultWitnessCommitment != "" {
+		commitScript, err := hex.DecodeString(tmpl.DefaultWitnessCommitment)
+		if err != nil {
+			t.Fatalf("decode witness commitment: %v", err)
+		}
+		coinbase.AddTxOut(wire.NewTxOut(0, commitScript))
+	}
+
+	// With one tx in the block, merkle root = coinbase txid.
+	merkleRoot := coinbase.TxHash()
+
+	block := wire.NewMsgBlock(&wire.BlockHeader{
+		Version:    tmpl.Version,
+		PrevBlock:  *prev,
+		MerkleRoot: merkleRoot,
+		Timestamp:  time.Unix(tmpl.MinTime+1, 0),
+		Bits:       bits,
+	})
+	block.AddTransaction(coinbase)
+
+	target := blockchain.CompactToBig(bits)
+	for nonce := uint32(0); nonce < (1 << 30); nonce++ {
+		block.Header.Nonce = nonce
+		h := block.Header.BlockHash()
+		if blockchain.HashToBig(&h).Cmp(target) <= 0 {
+			return block
+		}
+	}
+	t.Fatal("could not solve regtest PoW within nonce range")
+	return nil
+}
+
+// TestRPC_GetBlockTemplate_SubmitBlock pins the consensus-test path: assemble
+// a block from the template, submit it, observe the height advance. This is
+// the "include a tx in a block without going through the mempool" pattern
+// soft-fork tests rely on.
+func TestRPC_GetBlockTemplate_SubmitBlock(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(minerWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(minerWallet)
+
+	miner, err := rt.GenerateBech32(minerWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+	if err := rt.Warp(101, miner); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	tmpl, err := rt.GetBlockTemplate(&btcjson.TemplateRequest{
+		Mode:  "template",
+		Rules: []string{"segwit"},
+	})
+	if err != nil {
+		t.Fatalf("GetBlockTemplate: %v", err)
+	}
+	if tmpl.Height <= 0 || tmpl.PreviousHash == "" || tmpl.Bits == "" {
+		t.Fatalf("template missing required fields: %+v", tmpl)
+	}
+
+	startHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount: %v", err)
+	}
+	if tmpl.Height != startHeight+1 {
+		t.Fatalf("template height %d != current+1 (%d)", tmpl.Height, startHeight+1)
+	}
+
+	block := assembleTrivialRegtestBlock(t, tmpl)
+	if err := rt.SubmitBlock(block); err != nil {
+		t.Fatalf("SubmitBlock: %v", err)
+	}
+
+	endHeight, err := rt.GetBlockCount()
+	if err != nil {
+		t.Fatalf("GetBlockCount after submit: %v", err)
+	}
+	if endHeight != startHeight+1 {
+		t.Errorf("expected height %d -> %d, got %d", startHeight, startHeight+1, endHeight)
+	}
+}
+
+// TestRPC_SubmitBlock_Invalid pins the error-path contract: bitcoind rejects
+// a malformed block with a meaningful error rather than a panic. The empty
+// block has no coinbase so it trips bitcoind's basic structural validation.
+func TestRPC_SubmitBlock_Invalid(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	bogus := &wire.MsgBlock{Header: wire.BlockHeader{}}
+	err = rt.SubmitBlock(bogus)
+	if err == nil {
+		t.Fatal("expected SubmitBlock(empty) to error, got nil")
+	}
+	if err := rt.SubmitBlock(nil); err == nil {
+		t.Error("expected SubmitBlock(nil) to error, got nil")
+	}
+}
+
+// TestRPC_CreateRawTransaction_DecodeRoundTrip pins the round-trip contract:
+// the tx we build through CreateRawTransaction round-trips through
+// DecodeRawTransaction with matching inputs and outputs.
+func TestRPC_CreateRawTransaction_DecodeRoundTrip(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(userWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(userWallet)
+
+	addrStr, err := rt.GenerateBech32(userWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+	addr, err := btcutil.DecodeAddress(addrStr, &chaincfg.RegressionNetParams)
+	if err != nil {
+		t.Fatalf("DecodeAddress: %v", err)
+	}
+
+	// Synthetic input — DecodeRawTransaction is a pure-decode RPC, so the
+	// outpoint doesn't have to exist on chain.
+	dummyTxid := "00000000000000000000000000000000000000000000000000000000deadbeef"
+	inputs := []btcjson.TransactionInput{{Txid: dummyTxid, Vout: 7}}
+	amounts := map[btcutil.Address]btcutil.Amount{addr: btcutil.Amount(50_000)}
+
+	tx, err := rt.CreateRawTransaction(inputs, amounts, nil)
+	if err != nil {
+		t.Fatalf("CreateRawTransaction: %v", err)
+	}
+	if len(tx.TxIn) != 1 {
+		t.Fatalf("expected 1 vin, got %d", len(tx.TxIn))
+	}
+	if tx.TxIn[0].PreviousOutPoint.Index != 7 {
+		t.Errorf("vout = %d, want 7", tx.TxIn[0].PreviousOutPoint.Index)
+	}
+	if got := tx.TxIn[0].PreviousOutPoint.Hash.String(); got != dummyTxid {
+		t.Errorf("vin txid = %s, want %s", got, dummyTxid)
+	}
+	if len(tx.TxOut) != 1 {
+		t.Fatalf("expected 1 vout, got %d", len(tx.TxOut))
+	}
+	if tx.TxOut[0].Value != 50_000 {
+		t.Errorf("vout value = %d, want 50000", tx.TxOut[0].Value)
+	}
+
+	res, err := rt.DecodeRawTransaction(tx)
+	if err != nil {
+		t.Fatalf("DecodeRawTransaction: %v", err)
+	}
+	if len(res.Vin) != 1 {
+		t.Errorf("decoded vin len = %d, want 1", len(res.Vin))
+	}
+	if len(res.Vout) != 1 {
+		t.Errorf("decoded vout len = %d, want 1", len(res.Vout))
+	}
+	if res.Vin[0].Txid != dummyTxid {
+		t.Errorf("decoded vin txid = %s, want %s", res.Vin[0].Txid, dummyTxid)
+	}
+	if res.Vin[0].Vout != 7 {
+		t.Errorf("decoded vin vout = %d, want 7", res.Vin[0].Vout)
+	}
+	if res.Vout[0].Value != 0.0005 { // 50000 sats = 0.0005 BTC
+		t.Errorf("decoded vout value = %v, want 0.0005", res.Vout[0].Value)
+	}
+}
+
+// TestRPC_DecodeRawTransaction_Nil pins the nil-input validation path.
+func TestRPC_DecodeRawTransaction_Nil(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if _, err := rt.DecodeRawTransaction(nil); err == nil {
+		t.Error("DecodeRawTransaction(nil) should return validation error")
+	}
+}
+
+// TestRPC_DecodeScript_P2TR pins that DecodeScript returns the correct script
+// type and disassembled ASM for a P2TR (Taproot) scriptPubKey. The script is
+// fixed-shape: OP_1 <32-byte x-only pubkey>.
+func TestRPC_DecodeScript_P2TR(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(userWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(userWallet)
+
+	taprootAddr, err := rt.GenerateBech32m(userWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32m: %v", err)
+	}
+	addr, err := btcutil.DecodeAddress(taprootAddr, &chaincfg.RegressionNetParams)
+	if err != nil {
+		t.Fatalf("DecodeAddress: %v", err)
+	}
+	pkScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("PayToAddrScript: %v", err)
+	}
+
+	res, err := rt.DecodeScript(hex.EncodeToString(pkScript))
+	if err != nil {
+		t.Fatalf("DecodeScript: %v", err)
+	}
+	if res.Type != "witness_v1_taproot" {
+		t.Errorf("script type = %q, want witness_v1_taproot", res.Type)
+	}
+	if res.Asm == "" {
+		t.Error("Asm should be non-empty")
+	}
+}
+
+// TestRPC_DecodeScript_Empty pins the empty-input validation path.
+func TestRPC_DecodeScript_Empty(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if _, err := rt.DecodeScript(""); err == nil {
+		t.Error("DecodeScript(\"\") should return validation error")
+	}
+}
+
+// TestRPC_FundRawTransaction pins that FundRawTransaction can take an empty
+// (output-only) tx and add inputs plus a change output drawn from the wallet's
+// mature UTXOs. This is the bridge between CreateRawTransaction and the
+// existing SignRawTransactionWithWallet → BroadcastTransaction flow.
+func TestRPC_FundRawTransaction(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if err := rt.EnsureWallet(userWallet); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	defer rt.UnloadWallet(userWallet)
+
+	miner, err := rt.GenerateBech32(userWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32 miner: %v", err)
+	}
+	dest, err := rt.GenerateBech32(userWallet)
+	if err != nil {
+		t.Fatalf("GenerateBech32 dest: %v", err)
+	}
+	destAddr, err := btcutil.DecodeAddress(dest, &chaincfg.RegressionNetParams)
+	if err != nil {
+		t.Fatalf("DecodeAddress: %v", err)
+	}
+	if err := rt.Warp(101, miner); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	pkScript, err := txscript.PayToAddrScript(destAddr)
+	if err != nil {
+		t.Fatalf("PayToAddrScript: %v", err)
+	}
+	skel := wire.NewMsgTx(2)
+	skel.AddTxOut(wire.NewTxOut(50_000, pkScript))
+
+	res, err := rt.FundRawTransaction(skel, nil)
+	if err != nil {
+		t.Fatalf("FundRawTransaction: %v", err)
+	}
+	if res.Transaction == nil {
+		t.Fatal("Transaction is nil")
+	}
+	if len(res.Transaction.TxIn) == 0 {
+		t.Error("expected at least one input added")
+	}
+	if len(res.Transaction.TxOut) < 2 {
+		t.Errorf("expected at least 2 outputs (target + change), got %d", len(res.Transaction.TxOut))
+	}
+	if res.ChangePosition < 0 {
+		t.Errorf("ChangePosition = %d, want >= 0", res.ChangePosition)
+	}
+	if res.Fee <= 0 {
+		t.Errorf("Fee = %v, want > 0", res.Fee)
+	}
+}
+
+// TestRPC_FundRawTransaction_Nil pins the nil-input validation path.
+func TestRPC_FundRawTransaction_Nil(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if _, err := rt.FundRawTransaction(nil, nil); err == nil {
+		t.Error("FundRawTransaction(nil) should return validation error")
 	}
 }

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire"
@@ -425,6 +426,24 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 		}},
 		{"MineUntilActive", func() error {
 			_, err := rt.MineUntilActive("testdummy", "bcrt1qvhadhnxjjeczwgm7y54m2dplur6q2895gtnthl", 100)
+			return err
+		}},
+		{"GetBlockTemplate", func() error {
+			_, err := rt.GetBlockTemplate(&btcjson.TemplateRequest{Mode: "template", Rules: []string{"segwit"}})
+			return err
+		}},
+		{"SubmitBlock", func() error { return rt.SubmitBlock(&wire.MsgBlock{}) }},
+		{"CreateRawTransaction", func() error {
+			_, err := rt.CreateRawTransaction(nil, nil, nil)
+			return err
+		}},
+		{"DecodeRawTransaction", func() error {
+			_, err := rt.DecodeRawTransaction(wire.NewMsgTx(2))
+			return err
+		}},
+		{"DecodeScript", func() error { _, err := rt.DecodeScript("00"); return err }},
+		{"FundRawTransaction", func() error {
+			_, err := rt.FundRawTransaction(wire.NewMsgTx(2), nil)
 			return err
 		}},
 	}

--- a/tx.go
+++ b/tx.go
@@ -284,6 +284,176 @@ func (r *Regtest) BroadcastTransactionContext(ctx context.Context, tx *wire.MsgT
 	return txid, nil
 }
 
+// CreateRawTransaction builds an unsigned transaction spending the given
+// inputs and paying the given amounts. The raw counterpart to SendToAddress —
+// returns the wire.MsgTx without signing or broadcasting, so the caller can
+// inspect, mutate, or sign it externally before submission.
+//
+// Parameters:
+//   - inputs: outpoints to spend (txid + vout per input).
+//   - amounts: address → amount map for the outputs.
+//   - lockTime: optional nLockTime; pass nil for none.
+//
+// Returns:
+//   - *wire.MsgTx: the unsigned transaction
+//   - error: errNotConnected before Start; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	addr, _ := btcutil.DecodeAddress("bcrt1q...", &chaincfg.RegressionNetParams)
+//	tx, err := rt.CreateRawTransaction(
+//	    []btcjson.TransactionInput{{Txid: "abc...", Vout: 0}},
+//	    map[btcutil.Address]btcutil.Amount{addr: btcutil.Amount(100_000)},
+//	    nil,
+//	)
+func (r *Regtest) CreateRawTransaction(inputs []btcjson.TransactionInput, amounts map[btcutil.Address]btcutil.Amount, lockTime *int64) (*wire.MsgTx, error) {
+	return r.CreateRawTransactionContext(context.Background(), inputs, amounts, lockTime)
+}
+
+// CreateRawTransactionContext is the context-aware variant of CreateRawTransaction.
+func (r *Regtest) CreateRawTransactionContext(ctx context.Context, inputs []btcjson.TransactionInput, amounts map[btcutil.Address]btcutil.Amount, lockTime *int64) (*wire.MsgTx, error) {
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	tx, err := runWithContext(ctx, func() (*wire.MsgTx, error) {
+		return client.CreateRawTransaction(inputs, amounts, lockTime)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("createrawtransaction: %w", err)
+	}
+	return tx, nil
+}
+
+// DecodeRawTransaction returns bitcoind's verbose decoding of a transaction:
+// txid/wtxid, version, locktime, and per-input/output details.
+//
+// Parameters:
+//   - tx: the transaction to decode (must be non-nil).
+//
+// Returns:
+//   - *btcjson.TxRawResult: decoded view of the transaction
+//   - error: validation error for nil tx; errNotConnected before Start;
+//     otherwise wrapped RPC error.
+//
+// Example:
+//
+//	res, err := rt.DecodeRawTransaction(tx)
+//	if err != nil { return err }
+//	fmt.Println("vsize:", res.Vsize, "vin:", len(res.Vin))
+func (r *Regtest) DecodeRawTransaction(tx *wire.MsgTx) (*btcjson.TxRawResult, error) {
+	return r.DecodeRawTransactionContext(context.Background(), tx)
+}
+
+// DecodeRawTransactionContext is the context-aware variant of DecodeRawTransaction.
+func (r *Regtest) DecodeRawTransactionContext(ctx context.Context, tx *wire.MsgTx) (*btcjson.TxRawResult, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("tx must not be nil")
+	}
+	var buf bytes.Buffer
+	if err := tx.Serialize(&buf); err != nil {
+		return nil, fmt.Errorf("serialize tx: %w", err)
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := runWithContext(ctx, func() (*btcjson.TxRawResult, error) {
+		return client.DecodeRawTransaction(buf.Bytes())
+	})
+	if err != nil {
+		return nil, fmt.Errorf("decoderawtransaction: %w", err)
+	}
+	return res, nil
+}
+
+// DecodeScript returns bitcoind's interpretation of a serialized script:
+// disassembled ASM, script type (e.g. "witness_v1_taproot"), and the
+// derived address(es) when applicable.
+//
+// Parameters:
+//   - scriptHex: serialized script as a hex string (must be non-empty).
+//
+// Returns:
+//   - *btcjson.DecodeScriptResult: ASM, type, and addresses
+//   - error: validation error for empty input; errNotConnected before Start;
+//     otherwise wrapped RPC error.
+//
+// Example:
+//
+//	res, err := rt.DecodeScript("5120...") // a P2TR scriptPubKey
+//	if err != nil { return err }
+//	fmt.Println("type:", res.Type)
+func (r *Regtest) DecodeScript(scriptHex string) (*btcjson.DecodeScriptResult, error) {
+	return r.DecodeScriptContext(context.Background(), scriptHex)
+}
+
+// DecodeScriptContext is the context-aware variant of DecodeScript.
+func (r *Regtest) DecodeScriptContext(ctx context.Context, scriptHex string) (*btcjson.DecodeScriptResult, error) {
+	if scriptHex == "" {
+		return nil, fmt.Errorf("scriptHex must not be empty")
+	}
+	scriptBytes, err := hex.DecodeString(scriptHex)
+	if err != nil {
+		return nil, fmt.Errorf("decode script hex: %w", err)
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := runWithContext(ctx, func() (*btcjson.DecodeScriptResult, error) {
+		return client.DecodeScript(scriptBytes)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("decodescript: %w", err)
+	}
+	return res, nil
+}
+
+// FundRawTransaction adds inputs and a change output to a transaction so it
+// can be signed and broadcast. The wallet picks UTXOs from its mature balance.
+//
+// Parameters:
+//   - tx: the partially-built transaction (outputs at minimum; inputs optional).
+//   - opts: fund options; pass nil for defaults.
+//
+// Returns:
+//   - *btcjson.FundRawTransactionResult: the funded tx, fee paid, and the
+//     change-output index.
+//   - error: validation error for nil tx; errNotConnected before Start;
+//     otherwise wrapped RPC error (e.g. "Insufficient funds").
+//
+// Example:
+//
+//	out := wire.NewTxOut(50_000, p2trScript)
+//	tx := wire.NewMsgTx(2); tx.AddTxOut(out)
+//	res, err := rt.FundRawTransaction(tx, nil)
+func (r *Regtest) FundRawTransaction(tx *wire.MsgTx, opts *btcjson.FundRawTransactionOpts) (*btcjson.FundRawTransactionResult, error) {
+	return r.FundRawTransactionContext(context.Background(), tx, opts)
+}
+
+// FundRawTransactionContext is the context-aware variant of FundRawTransaction.
+func (r *Regtest) FundRawTransactionContext(ctx context.Context, tx *wire.MsgTx, opts *btcjson.FundRawTransactionOpts) (*btcjson.FundRawTransactionResult, error) {
+	if tx == nil {
+		return nil, fmt.Errorf("tx must not be nil")
+	}
+	o := btcjson.FundRawTransactionOpts{}
+	if opts != nil {
+		o = *opts
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return nil, err
+	}
+	res, err := runWithContext(ctx, func() (*btcjson.FundRawTransactionResult, error) {
+		return client.FundRawTransaction(tx, o, nil)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("fundrawtransaction: %w", err)
+	}
+	return res, nil
+}
+
 // MempoolAcceptResult is the per-tx result of TestMempoolAccept.
 type MempoolAcceptResult struct {
 	// TxID is the transaction hash in hex.


### PR DESCRIPTION
## Summary

- New \`block.go\` with \`GetBlockTemplate\` / \`SubmitBlock\` for the consensus-test path: include a tx in a block without going through the mempool.
- New raw-tx wrappers in \`tx.go\`: \`CreateRawTransaction\`, \`DecodeRawTransaction\`, \`DecodeScript\`, \`FundRawTransaction\` — round out the toolkit alongside existing \`SignRawTransactionWithWallet\` / \`BroadcastTransaction\`.
- All \`*Context\` variants follow the established pattern. README \"API Reference\" updated.

Closes #75, #76.

## Test plan

- [x] \`TestRPC_GetBlockTemplate_SubmitBlock\` — assembles a trivial regtest block from the template (BIP34 coinbase, witness commitment, brute-force PoW) and confirms height +1
- [x] \`TestRPC_SubmitBlock_Invalid\` — empty / nil block returns a meaningful error, no panic
- [x] \`TestRPC_CreateRawTransaction_DecodeRoundTrip\` — inputs/outputs match round-trip
- [x] \`TestRPC_DecodeScript_P2TR\` — script type \"witness_v1_taproot\", non-empty ASM
- [x] \`TestRPC_FundRawTransaction\` — adds inputs and change to an output-only tx
- [x] Validation paths: \`DecodeRawTransaction(nil)\`, \`DecodeScript(\"\")\`, \`FundRawTransaction(nil)\`
- [x] \`Test_RPCMethods_BeforeStart\` extended with all six new methods
- [x] \`make ai-check\` clean (fmt + vet + lint + test-race + vuln)

🤖 Generated with [Claude Code](https://claude.com/claude-code)