### PR TITLE
[Phase 5.D.2] Multi-node P2P: Connect / Disconnect / AddNode

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ type Config struct {
 
 **Transactions:** `SendToAddress(address, sats)`, `GetTxOut(txid, vout, includeMempool)`, `ScanTxOutSetForAddress(address)`, `SignRawTransactionWithWallet(tx)`, `BroadcastTransaction(tx)`, `CreateRawTransaction(inputs, amounts, lockTime)`, `DecodeRawTransaction(tx)`, `DecodeScript(scriptHex)`, `FundRawTransaction(tx, opts)`, `TestMempoolAccept(txs...)`
 
+**Peers:** `Connect(other)`, `Disconnect(other)`, `AddNode(host)`, `GetConnectionCount()`
+
 Every RPC-issuing method also has a `*Context` variant (`StartContext`, `GetBlockCountContext`, `WarpContext`, etc.) that accepts a `context.Context` for timeout and cancellation. The non-`Context` form is a thin `context.Background()` wrapper.
 
 See [godoc](https://pkg.go.dev/github.com/neverDefined/go-regtest) for detailed API documentation.

--- a/peer.go
+++ b/peer.go
@@ -1,0 +1,186 @@
+package regtest
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/btcsuite/btcd/rpcclient"
+)
+
+// extractP2PPort returns the P2P listening port for a host string in
+// "host:rpcport" form, mirroring scripts/bitcoind_manager.sh which derives
+// P2P_PORT = RPC_PORT + 1. Returns the empty string when the host has no
+// explicit port (in which case the caller should fall back to the default
+// regtest P2P port, 18444).
+func extractP2PPort(host string) string {
+	idx := strings.LastIndex(host, ":")
+	if idx < 0 || idx == len(host)-1 {
+		return ""
+	}
+	rpcStr := host[idx+1:]
+	rpc, err := strconv.Atoi(rpcStr)
+	if err != nil {
+		return ""
+	}
+	return strconv.Itoa(rpc + 1)
+}
+
+// peerAddress builds the "host:p2p_port" address other should be reached at,
+// derived from its Config().Host using the script's RPC+1 convention.
+func peerAddress(other *Regtest) (string, error) {
+	if other == nil {
+		return "", fmt.Errorf("peer must not be nil")
+	}
+	host := other.Config().Host
+	idx := strings.LastIndex(host, ":")
+	if idx < 0 {
+		return "", fmt.Errorf("peer host %q has no port", host)
+	}
+	p2p := extractP2PPort(host)
+	if p2p == "" {
+		return "", fmt.Errorf("peer host %q: cannot derive P2P port", host)
+	}
+	return host[:idx] + ":" + p2p, nil
+}
+
+// Connect tells this node to add the other regtest instance as a persistent
+// peer. The peer's P2P port is derived from its Config().Host using the
+// scripts/bitcoind_manager.sh convention (P2P = RPC + 1).
+//
+// Connect is asynchronous: bitcoind queues the addnode request and the
+// handshake completes shortly after the call returns. Tests that depend on
+// the connection being live should poll GetConnectionCount until it sees a
+// non-zero value.
+//
+// Parameters:
+//   - other: another running *Regtest instance (must not be nil)
+//
+// Returns:
+//   - error: validation error for nil peer or unparseable host;
+//     errNotConnected before Start; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	if err := rt1.Connect(rt2); err != nil { return err }
+//	// rt1 now has rt2 as a persistent peer.
+func (r *Regtest) Connect(other *Regtest) error {
+	return r.ConnectContext(context.Background(), other)
+}
+
+// ConnectContext is the context-aware variant of Connect.
+func (r *Regtest) ConnectContext(ctx context.Context, other *Regtest) error {
+	addr, err := peerAddress(other)
+	if err != nil {
+		return err
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return err
+	}
+	_, err = runWithContext(ctx, func() (struct{}, error) {
+		return struct{}{}, client.AddNode(addr, rpcclient.ANAdd)
+	})
+	if err != nil {
+		return fmt.Errorf("connect %s: %w", addr, err)
+	}
+	return nil
+}
+
+// Disconnect drops the live connection to the other node via the
+// disconnectnode RPC. Useful for inducing a network partition in
+// reorg/propagation tests.
+//
+// Parameters:
+//   - other: another running *Regtest instance (must not be nil)
+//
+// Returns:
+//   - error: validation error for nil peer or unparseable host;
+//     errNotConnected before Start; otherwise wrapped RPC error (including
+//     bitcoind's "Node not found in connected nodes" if the peer was never
+//     connected).
+//
+// Example:
+//
+//	if err := rt1.Disconnect(rt2); err != nil { return err }
+func (r *Regtest) Disconnect(other *Regtest) error {
+	return r.DisconnectContext(context.Background(), other)
+}
+
+// DisconnectContext is the context-aware variant of Disconnect.
+func (r *Regtest) DisconnectContext(ctx context.Context, other *Regtest) error {
+	addr, err := peerAddress(other)
+	if err != nil {
+		return err
+	}
+	if _, err := r.rawRPC(ctx, "disconnectnode", addr); err != nil {
+		return fmt.Errorf("disconnect %s: %w", addr, err)
+	}
+	return nil
+}
+
+// AddNode is the lower-level escape hatch for connecting to a host bitcoind
+// reachable at an arbitrary "host:p2p_port" address. Prefer Connect when both
+// nodes are *Regtest instances managed by this library.
+//
+// Parameters:
+//   - host: peer address ("host:port"). Must be non-empty.
+//
+// Returns:
+//   - error: validation error for empty host; errNotConnected before Start;
+//     otherwise wrapped RPC error.
+//
+// Example:
+//
+//	if err := rt.AddNode("127.0.0.1:18444"); err != nil { return err }
+func (r *Regtest) AddNode(host string) error {
+	return r.AddNodeContext(context.Background(), host)
+}
+
+// AddNodeContext is the context-aware variant of AddNode.
+func (r *Regtest) AddNodeContext(ctx context.Context, host string) error {
+	if host == "" {
+		return fmt.Errorf("host must not be empty")
+	}
+	client, err := r.lockedClient()
+	if err != nil {
+		return err
+	}
+	_, err = runWithContext(ctx, func() (struct{}, error) {
+		return struct{}{}, client.AddNode(host, rpcclient.ANAdd)
+	})
+	if err != nil {
+		return fmt.Errorf("addnode %s: %w", host, err)
+	}
+	return nil
+}
+
+// GetConnectionCount returns the number of peers currently connected to this
+// node. Use it to confirm that a Connect call has produced a live link
+// (bitcoind's addnode is asynchronous, so the count may briefly read 0).
+//
+// Returns:
+//   - int64: number of active peer connections
+//   - error: errNotConnected before Start; otherwise wrapped RPC error.
+//
+// Example:
+//
+//	if n, err := rt.GetConnectionCount(); err != nil { return err
+//	} else if n == 0 { /* still connecting */ }
+func (r *Regtest) GetConnectionCount() (int64, error) {
+	return r.GetConnectionCountContext(context.Background())
+}
+
+// GetConnectionCountContext is the context-aware variant of GetConnectionCount.
+func (r *Regtest) GetConnectionCountContext(ctx context.Context) (int64, error) {
+	client, err := r.lockedClient()
+	if err != nil {
+		return 0, err
+	}
+	n, err := runWithContext(ctx, client.GetConnectionCount)
+	if err != nil {
+		return 0, fmt.Errorf("getconnectioncount: %w", err)
+	}
+	return n, nil
+}

--- a/regtest_test.go
+++ b/regtest_test.go
@@ -446,6 +446,10 @@ func Test_RPCMethods_BeforeStart(t *testing.T) {
 			_, err := rt.FundRawTransaction(wire.NewMsgTx(2), nil)
 			return err
 		}},
+		{"Connect", func() error { return rt.Connect(&Regtest{config: DefaultConfig()}) }},
+		{"Disconnect", func() error { return rt.Disconnect(&Regtest{config: DefaultConfig()}) }},
+		{"AddNode", func() error { return rt.AddNode("127.0.0.1:18444") }},
+		{"GetConnectionCount", func() error { _, err := rt.GetConnectionCount(); return err }},
 	}
 	for _, c := range checks {
 		t.Run(c.name, func(t *testing.T) {
@@ -816,6 +820,145 @@ func Test_ExtraArgs_Forwarded(t *testing.T) {
 	}
 	if !categories["mempool"] {
 		t.Errorf("expected mempool=true with -debug=mempool, got: %v", categories)
+	}
+}
+
+// Test_ExtractP2PPort pins the host-parsing contract: the P2P port is RPC+1
+// per scripts/bitcoind_manager.sh, and unparseable hosts return the empty
+// string so callers can fall back cleanly.
+func Test_ExtractP2PPort(t *testing.T) {
+	cases := []struct {
+		host string
+		want string
+	}{
+		{"127.0.0.1:18443", "18444"},
+		{"127.0.0.1:20000", "20001"},
+		{"localhost:8332", "8333"},
+		{"127.0.0.1", ""},     // no port
+		{"", ""},              // empty
+		{"127.0.0.1:", ""},    // trailing colon
+		{"127.0.0.1:abc", ""}, // non-numeric port
+	}
+	for _, tc := range cases {
+		t.Run(tc.host, func(t *testing.T) {
+			if got := extractP2PPort(tc.host); got != tc.want {
+				t.Errorf("extractP2PPort(%q) = %q, want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+// Test_MultiNode_Connect_Sync exercises the full multi-node story: start two
+// regtest nodes, Connect rt1 -> rt2, observe GetConnectionCount go positive
+// on both within a timeout, then Warp on rt1 and confirm rt2's height
+// matches via header propagation. Closes the harness gap that blocked
+// reorg-style soft-fork tests.
+func Test_MultiNode_Connect_Sync(t *testing.T) {
+	rt1, err := New(&Config{
+		Host:    "127.0.0.1:20000",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: filepath.Join(t.TempDir(), "rt1"),
+	})
+	if err != nil {
+		t.Fatalf("New rt1: %v", err)
+	}
+	t.Cleanup(func() { _ = rt1.Stop(); _ = rt1.Cleanup() })
+
+	rt2, err := New(&Config{
+		Host:    "127.0.0.1:20100",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: filepath.Join(t.TempDir(), "rt2"),
+	})
+	if err != nil {
+		t.Fatalf("New rt2: %v", err)
+	}
+	t.Cleanup(func() { _ = rt2.Stop(); _ = rt2.Cleanup() })
+
+	if err := rt1.Start(); err != nil {
+		t.Fatalf("Start rt1: %v", err)
+	}
+	if err := rt2.Start(); err != nil {
+		t.Fatalf("Start rt2: %v", err)
+	}
+
+	if err := rt1.Connect(rt2); err != nil {
+		t.Fatalf("rt1.Connect(rt2): %v", err)
+	}
+
+	// addnode is asynchronous; poll until both sides see the link.
+	deadline := time.Now().Add(15 * time.Second)
+	for {
+		n1, err := rt1.GetConnectionCount()
+		if err != nil {
+			t.Fatalf("rt1.GetConnectionCount: %v", err)
+		}
+		n2, err := rt2.GetConnectionCount()
+		if err != nil {
+			t.Fatalf("rt2.GetConnectionCount: %v", err)
+		}
+		if n1 >= 1 && n2 >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nodes never connected: n1=%d n2=%d", n1, n2)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if err := rt1.EnsureWallet("miner"); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	miner, err := rt1.GenerateBech32("miner")
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+	if err := rt1.Warp(5, miner); err != nil {
+		t.Fatalf("Warp: %v", err)
+	}
+
+	want, err := rt1.GetBlockCount()
+	if err != nil {
+		t.Fatalf("rt1.GetBlockCount: %v", err)
+	}
+
+	deadline = time.Now().Add(15 * time.Second)
+	for {
+		got, err := rt2.GetBlockCount()
+		if err != nil {
+			t.Fatalf("rt2.GetBlockCount: %v", err)
+		}
+		if got == want {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rt2 never caught up: rt1=%d rt2=%d", want, got)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Disconnect should drop the link; verify both connection counts return to 0.
+	if err := rt1.Disconnect(rt2); err != nil {
+		t.Fatalf("rt1.Disconnect(rt2): %v", err)
+	}
+	deadline = time.Now().Add(10 * time.Second)
+	for {
+		n1, err := rt1.GetConnectionCount()
+		if err != nil {
+			t.Fatalf("rt1.GetConnectionCount post-disconnect: %v", err)
+		}
+		n2, err := rt2.GetConnectionCount()
+		if err != nil {
+			t.Fatalf("rt2.GetConnectionCount post-disconnect: %v", err)
+		}
+		if n1 == 0 && n2 == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nodes never disconnected: n1=%d n2=%d", n1, n2)
+		}
+		time.Sleep(200 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary

- New \`peer.go\` with \`Connect\` / \`Disconnect\` / \`AddNode\` / \`GetConnectionCount\` so two \`*Regtest\` instances can be wired into a real P2P link without Docker.
- \`extractP2PPort\` derives the peer port from \`Config().Host\` using the script convention (P2P = RPC + 1) and returns "" on unparseable input so callers can fall back cleanly.
- README "API Reference" gains a new "Peers" line.

Closes #79.

## Test plan

- [x] \`Test_ExtractP2PPort\` — table-driven coverage of valid hosts, missing port, trailing colon, non-numeric port
- [x] \`Test_MultiNode_Connect_Sync\` — two real nodes on ports 20000/20100, \`rt1.Connect(rt2)\`, poll until both see ≥1 connection, Warp on rt1 → rt2 catches up via header propagation, \`Disconnect\` returns counts to 0
- [x] \`Test_RPCMethods_BeforeStart\` extended with all four new methods
- [x] \`make ai-check\` clean (fmt + vet + lint + test-race + vuln)

🤖 Generated with [Claude Code](https://claude.com/claude-code)