### PR TITLE
add BIPID registry, ListDeployments, SupportsBIP, MineUntilActiveBIP (#100, #101, #102)

### DIFF
--- a/deployments.go
+++ b/deployments.go
@@ -1,0 +1,339 @@
+package regtest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// BIPID identifies a Bitcoin Improvement Proposal that this library tracks
+// in its curated registry. BIP IDs are typed constants — prefer them over
+// stringly-typed deployment names (e.g. "checktemplateverify") so callers
+// avoid typos and pick up renames automatically when bitcoind changes a
+// deployment key.
+//
+// New BIPs can be added without breaking the iota ordering: append to the
+// const block and the registry. Reordering existing entries is a breaking
+// change for callers that persist BIPIDs.
+type BIPID int
+
+const (
+	// BIPUnknown is the zero value, returned when an EnrichedDeployment's
+	// deployment key isn't tracked by this library's registry.
+	BIPUnknown BIPID = iota
+	// BIPTestdummy is Bitcoin Core's regtest-only "testdummy" deployment.
+	// Used by activation tests in this library; not BIP-numbered.
+	BIPTestdummy
+	// BIPTaproot covers BIP340 (Schnorr signatures), BIP341 (Taproot), and
+	// BIP342 (Tapscript). Buried as of Bitcoin Core 22.
+	BIPTaproot
+	// BIP54 is Consensus Cleanup. Active on Bitcoin Inquisition 29.2+.
+	BIP54
+	// BIP118 is SIGHASH_ANYPREVOUT (APO/eltoo). Active on Bitcoin
+	// Inquisition.
+	BIP118
+	// BIP119 is OP_CHECKTEMPLATEVERIFY (CTV). Active on Bitcoin Inquisition.
+	BIP119
+	// BIP347 is OP_CAT. Active on Bitcoin Inquisition.
+	BIP347
+	// BIP348 is OP_CHECKSIGFROMSTACK (CSFS). Active on Bitcoin Inquisition.
+	BIP348
+	// BIP349 is OP_INTERNALKEY. Active on Bitcoin Inquisition.
+	BIP349
+)
+
+// String returns a compact, human-readable name for the BIPID — "BIP119" for
+// BIP-numbered entries, the registry name for others ("testdummy",
+// "Taproot"), and "BIPUnknown" for unregistered values.
+func (b BIPID) String() string {
+	m, ok := metaByBIP(b)
+	if !ok {
+		return "BIPUnknown"
+	}
+	if m.bipNumber > 0 {
+		return fmt.Sprintf("BIP%d", m.bipNumber)
+	}
+	return m.name
+}
+
+// ErrUnknownBIP is returned by registry-aware methods (SupportsBIP,
+// MineUntilActiveBIP) when the supplied BIPID isn't in the curated registry.
+// Use errors.Is to detect it; do not string-match.
+var ErrUnknownBIP = errors.New("unknown BIP")
+
+// bipMeta is the curated metadata for a BIP tracked by this library.
+type bipMeta struct {
+	id              BIPID
+	deployment      string  // matches getdeploymentinfo key
+	bipNumber       int     // 0 for non-numbered deployments (testdummy)
+	name            string  // human-readable feature name
+	docURL          string  // link to the BIP text or upstream tracking issue
+	expectedVariant Variant // VariantCore for testdummy/taproot, VariantInquisition for the rest
+}
+
+// bipRegistry is the package-private source of truth mapping each BIPID to
+// its bitcoind deployment key, BIP number, name, and doc URL. Deployment key
+// strings were verified against Bitcoin Inquisition 29.2's getdeploymentinfo
+// output (2026-04); Core's testdummy/taproot keys are stable across 24+.
+var bipRegistry = []bipMeta{
+	{
+		id:              BIPTestdummy,
+		deployment:      "testdummy",
+		bipNumber:       0,
+		name:            "testdummy",
+		docURL:          "https://github.com/bitcoin/bitcoin/blob/master/src/kernel/chainparams.cpp",
+		expectedVariant: VariantCore,
+	},
+	{
+		id:              BIPTaproot,
+		deployment:      "taproot",
+		bipNumber:       341,
+		name:            "Taproot",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki",
+		expectedVariant: VariantCore,
+	},
+	{
+		id:              BIP54,
+		deployment:      "consensuscleanup",
+		bipNumber:       54,
+		name:            "Consensus Cleanup",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0054.mediawiki",
+		expectedVariant: VariantInquisition,
+	},
+	{
+		id:              BIP118,
+		deployment:      "anyprevout",
+		bipNumber:       118,
+		name:            "ANYPREVOUT",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0118.mediawiki",
+		expectedVariant: VariantInquisition,
+	},
+	{
+		id:              BIP119,
+		deployment:      "checktemplateverify",
+		bipNumber:       119,
+		name:            "OP_CHECKTEMPLATEVERIFY",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki",
+		expectedVariant: VariantInquisition,
+	},
+	{
+		id:              BIP347,
+		deployment:      "op_cat",
+		bipNumber:       347,
+		name:            "OP_CAT",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0347.mediawiki",
+		expectedVariant: VariantInquisition,
+	},
+	{
+		id:              BIP348,
+		deployment:      "checksigfromstack",
+		bipNumber:       348,
+		name:            "OP_CHECKSIGFROMSTACK",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0348.mediawiki",
+		expectedVariant: VariantInquisition,
+	},
+	{
+		id:              BIP349,
+		deployment:      "internalkey",
+		bipNumber:       349,
+		name:            "OP_INTERNALKEY",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0349.mediawiki",
+		expectedVariant: VariantInquisition,
+	},
+}
+
+// metaByBIP returns the registry entry for the given BIPID, or false when
+// the ID isn't registered. Linear scan is fine — the registry is short and
+// lookups happen only on test setup paths.
+func metaByBIP(b BIPID) (bipMeta, bool) {
+	for _, m := range bipRegistry {
+		if m.id == b {
+			return m, true
+		}
+	}
+	return bipMeta{}, false
+}
+
+// metaByDeployment returns the registry entry whose deployment key matches d,
+// or false when the key isn't tracked.
+func metaByDeployment(d string) (bipMeta, bool) {
+	for _, m := range bipRegistry {
+		if m.deployment == d {
+			return m, true
+		}
+	}
+	return bipMeta{}, false
+}
+
+// EnrichedDeployment is a single soft-fork deployment's live state joined with
+// curated registry metadata. Returned by ListDeployments. Deployments that
+// aren't in the registry are still returned (with BIP=BIPUnknown and zero
+// metadata) so callers can see future forks bitcoind reports before this
+// library is updated.
+type EnrichedDeployment struct {
+	// BIP is the typed BIPID from the registry, or BIPUnknown when the live
+	// deployment key isn't tracked by this library.
+	BIP BIPID
+	// BIPNumber is the canonical BIP number (e.g. 119 for BIP119), or 0 for
+	// deployments without one (testdummy, unknown).
+	BIPNumber int
+	// Name is the human-readable feature name from the registry, or empty
+	// for unknown deployments.
+	Name string
+	// DocURL points at the BIP text (or upstream tracking issue), or empty
+	// for unknown deployments.
+	DocURL string
+	// Deployment is the raw key bitcoind reports under getdeploymentinfo.
+	Deployment string
+	// Type is the deployment kind reported by bitcoind: "buried", "bip9",
+	// or "heretical" (Inquisition's signaling-without-version-bits scheme).
+	Type string
+	// Active reports whether the deployment is enforced as of the chain tip.
+	Active bool
+	// Status is the typed BIP9 status. SoftForkActive for active buried/
+	// heretical deployments; the BIP9 state-machine value for type=="bip9";
+	// SoftForkUnknown when bitcoind doesn't carry a recognizable status.
+	Status SoftForkStatus
+	// Height is the activation height for buried deployments and the
+	// activation block for active BIP9/heretical entries; 0 otherwise.
+	Height int64
+}
+
+// ListDeployments returns every soft-fork deployment the running node knows
+// about, joined with curated registry metadata where available.
+//
+// This is a convenience wrapper around ListDeploymentsContext that uses
+// context.Background().
+//
+// Returns:
+//   - []EnrichedDeployment: sorted alphabetically by Deployment for stable
+//     output across runs.
+//   - error: errNotConnected before Start; otherwise the wrapped
+//     getdeploymentinfo failure.
+//
+// Example:
+//
+//	deps, err := rt.ListDeployments()
+//	if err != nil { return err }
+//	for _, d := range deps {
+//	    fmt.Printf("%-22s %s (active=%v) %s\n",
+//	        d.Deployment, d.Status, d.Active, d.DocURL)
+//	}
+func (r *Regtest) ListDeployments() ([]EnrichedDeployment, error) {
+	return r.ListDeploymentsContext(context.Background())
+}
+
+// ListDeploymentsContext is the context-aware variant of ListDeployments.
+//
+// Parameters:
+//   - ctx: context for cancellation and timeout control.
+//
+// Returns:
+//   - []EnrichedDeployment: sorted alphabetically by Deployment.
+//   - error: errNotConnected before Start; otherwise the wrapped
+//     getdeploymentinfo failure.
+func (r *Regtest) ListDeploymentsContext(ctx context.Context) ([]EnrichedDeployment, error) {
+	info, err := r.GetDeploymentInfoContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]EnrichedDeployment, 0, len(info.Deployments))
+	for name, d := range info.Deployments {
+		ed := EnrichedDeployment{
+			Deployment: name,
+			Type:       d.Type,
+			Active:     d.Active,
+			Height:     d.Height,
+		}
+		switch {
+		case d.BIP9 != nil:
+			ed.Status = parseSoftForkStatus(d.BIP9.Status)
+		case d.Active:
+			ed.Status = SoftForkActive
+		default:
+			ed.Status = SoftForkUnknown
+		}
+		if m, ok := metaByDeployment(name); ok {
+			ed.BIP = m.id
+			ed.BIPNumber = m.bipNumber
+			ed.Name = m.name
+			ed.DocURL = m.docURL
+		}
+		out = append(out, ed)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Deployment < out[j].Deployment
+	})
+	return out, nil
+}
+
+// SupportsBIP reports whether the running bitcoind exposes the deployment
+// keyed by this BIPID. The check is live — it queries getdeploymentinfo and
+// looks for the registry's deployment key in the response — so a Core node
+// correctly returns false for Inquisition-only BIPs (BIP119, BIP118, etc.)
+// even though those BIPs are in the registry.
+//
+// This is the canonical "skip when missing" primitive:
+//
+//	if ok, _ := rt.SupportsBIP(regtest.BIP119); !ok {
+//	    t.Skip("requires bitcoind-inquisition")
+//	}
+//
+// Returns:
+//   - bool: true when the live response includes the BIPID's deployment key.
+//   - error: ErrUnknownBIP when the BIPID isn't in the registry;
+//     errNotConnected before Start; otherwise the wrapped
+//     getdeploymentinfo failure.
+func (r *Regtest) SupportsBIP(bip BIPID) (bool, error) {
+	return r.SupportsBIPContext(context.Background(), bip)
+}
+
+// SupportsBIPContext is the context-aware variant of SupportsBIP.
+func (r *Regtest) SupportsBIPContext(ctx context.Context, bip BIPID) (bool, error) {
+	m, ok := metaByBIP(bip)
+	if !ok {
+		return false, fmt.Errorf("%w: %d", ErrUnknownBIP, bip)
+	}
+	info, err := r.GetDeploymentInfoContext(ctx)
+	if err != nil {
+		return false, err
+	}
+	_, present := info.Deployments[m.deployment]
+	return present, nil
+}
+
+// MineUntilActiveBIP is the typed alternative to MineUntilActive — translate a
+// BIPID to its registry deployment key, then drive the BIP9 state machine
+// (or buried/heretical activation) to SoftForkActive.
+//
+// Parameters:
+//   - bip: typed BIP identifier from the registry. ErrUnknownBIP otherwise.
+//   - miner: address that receives coinbase rewards while mining activation
+//     windows.
+//   - maxBlocks: hard cap on blocks mined; >0.
+//
+// Returns:
+//   - int64: blocks actually mined.
+//   - error: ErrUnknownBIP for unregistered BIPs; same error semantics as
+//     MineUntilActiveContext otherwise (validation, RPC, SoftForkFailed).
+//
+// Example:
+//
+//	mined, err := rt.MineUntilActiveBIP(regtest.BIP119, addr, 2000)
+//	if errors.Is(err, regtest.ErrUnknownBIP) {
+//	    t.Skipf("BIP119 not in registry: %v", err)
+//	}
+func (r *Regtest) MineUntilActiveBIP(bip BIPID, miner string, maxBlocks int64) (int64, error) {
+	return r.MineUntilActiveBIPContext(context.Background(), bip, miner, maxBlocks)
+}
+
+// MineUntilActiveBIPContext is the context-aware variant of MineUntilActiveBIP.
+func (r *Regtest) MineUntilActiveBIPContext(ctx context.Context, bip BIPID, miner string, maxBlocks int64) (int64, error) {
+	m, ok := metaByBIP(bip)
+	if !ok {
+		return 0, fmt.Errorf("%w: %d", ErrUnknownBIP, bip)
+	}
+	return r.MineUntilActiveContext(ctx, m.deployment, miner, maxBlocks)
+}

--- a/deployments.go
+++ b/deployments.go
@@ -98,7 +98,7 @@ var bipRegistry = []bipMeta{
 		deployment:      "consensuscleanup",
 		bipNumber:       54,
 		name:            "Consensus Cleanup",
-		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0054.mediawiki",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0054.md",
 		expectedVariant: VariantInquisition,
 	},
 	{
@@ -130,7 +130,7 @@ var bipRegistry = []bipMeta{
 		deployment:      "checksigfromstack",
 		bipNumber:       348,
 		name:            "OP_CHECKSIGFROMSTACK",
-		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0348.mediawiki",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0348.md",
 		expectedVariant: VariantInquisition,
 	},
 	{
@@ -138,7 +138,7 @@ var bipRegistry = []bipMeta{
 		deployment:      "internalkey",
 		bipNumber:       349,
 		name:            "OP_INTERNALKEY",
-		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0349.mediawiki",
+		docURL:          "https://github.com/bitcoin/bips/blob/master/bip-0349.md",
 		expectedVariant: VariantInquisition,
 	},
 }

--- a/regtest_rpc_test.go
+++ b/regtest_rpc_test.go
@@ -1717,3 +1717,241 @@ func Test_ParseVariant(t *testing.T) {
 		})
 	}
 }
+
+// Test_BIPRegistry_Shape pins the integrity of bipRegistry: every BIPID
+// constant has exactly one entry; deployment keys, BIPIDs, and BIP numbers
+// are unique; no zero/empty leaks. Pure unit test — no node spawned.
+func Test_BIPRegistry_Shape(t *testing.T) {
+	wantIDs := []BIPID{
+		BIPTestdummy, BIPTaproot,
+		BIP54, BIP118, BIP119, BIP347, BIP348, BIP349,
+	}
+
+	seenID := make(map[BIPID]bool)
+	seenDeployment := make(map[string]bool)
+	seenBIPNumber := make(map[int]bool)
+
+	for _, m := range bipRegistry {
+		if m.id == BIPUnknown {
+			t.Errorf("bipRegistry must not contain BIPUnknown")
+		}
+		if seenID[m.id] {
+			t.Errorf("duplicate BIPID in registry: %d", m.id)
+		}
+		seenID[m.id] = true
+
+		if m.deployment == "" {
+			t.Errorf("registry entry %d has empty deployment key", m.id)
+		}
+		if seenDeployment[m.deployment] {
+			t.Errorf("duplicate deployment key in registry: %q", m.deployment)
+		}
+		seenDeployment[m.deployment] = true
+
+		if m.bipNumber > 0 {
+			if seenBIPNumber[m.bipNumber] {
+				t.Errorf("duplicate BIP number in registry: %d", m.bipNumber)
+			}
+			seenBIPNumber[m.bipNumber] = true
+		}
+		if m.name == "" {
+			t.Errorf("registry entry %d has empty name", m.id)
+		}
+		if m.docURL == "" {
+			t.Errorf("registry entry %d has empty docURL", m.id)
+		}
+	}
+
+	for _, want := range wantIDs {
+		if !seenID[want] {
+			t.Errorf("BIPID %d (%s) missing from registry", want, want)
+		}
+	}
+}
+
+// Test_BIPID_String pins the human-readable name format for logging.
+func Test_BIPID_String(t *testing.T) {
+	cases := []struct {
+		bip  BIPID
+		want string
+	}{
+		{BIPUnknown, "BIPUnknown"},
+		{BIPTestdummy, "testdummy"},
+		{BIPTaproot, "BIP341"},
+		{BIP54, "BIP54"},
+		{BIP119, "BIP119"},
+		{BIP347, "BIP347"},
+		{BIPID(9999), "BIPUnknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.bip.String(); got != tc.want {
+			t.Errorf("BIPID(%d).String() = %q, want %q", tc.bip, got, tc.want)
+		}
+	}
+}
+
+// Test_MetaLookups confirms metaByBIP and metaByDeployment round-trip for
+// every registry entry, and return false for unknown lookups.
+func Test_MetaLookups(t *testing.T) {
+	for _, m := range bipRegistry {
+		got, ok := metaByBIP(m.id)
+		if !ok || got.deployment != m.deployment {
+			t.Errorf("metaByBIP(%d) = (%v, %v), want (%+v, true)", m.id, got, ok, m)
+		}
+		got, ok = metaByDeployment(m.deployment)
+		if !ok || got.id != m.id {
+			t.Errorf("metaByDeployment(%q) = (%v, %v), want (%+v, true)", m.deployment, got, ok, m)
+		}
+	}
+	if _, ok := metaByBIP(BIPUnknown); ok {
+		t.Error("metaByBIP(BIPUnknown) should return false")
+	}
+	if _, ok := metaByDeployment("nonexistent-deployment"); ok {
+		t.Error("metaByDeployment(nonexistent) should return false")
+	}
+}
+
+// TestRPC_ListDeployments confirms the registry-joined view returns at least
+// taproot (buried, both variants) plus the variant-specific deployments, and
+// that registry metadata is populated for known keys.
+func TestRPC_ListDeployments(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	deps, err := rt.ListDeployments()
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(deps) == 0 {
+		t.Fatal("expected at least one deployment, got 0")
+	}
+
+	// Sorted by Deployment for stable output.
+	for i := 1; i < len(deps); i++ {
+		if deps[i-1].Deployment > deps[i].Deployment {
+			t.Errorf("deps not sorted: %q > %q", deps[i-1].Deployment, deps[i].Deployment)
+		}
+	}
+
+	byKey := make(map[string]EnrichedDeployment, len(deps))
+	for _, d := range deps {
+		byKey[d.Deployment] = d
+	}
+
+	tap, ok := byKey["taproot"]
+	if !ok {
+		t.Fatal("expected 'taproot' in ListDeployments output")
+	}
+	if tap.BIP != BIPTaproot {
+		t.Errorf("taproot BIP = %s, want BIPTaproot", tap.BIP)
+	}
+	if tap.BIPNumber != 341 {
+		t.Errorf("taproot BIPNumber = %d, want 341", tap.BIPNumber)
+	}
+	if !tap.Active {
+		t.Error("taproot should be Active on regtest")
+	}
+	if tap.DocURL == "" {
+		t.Error("taproot should have a DocURL from registry join")
+	}
+}
+
+// TestRPC_SupportsBIP_Testdummy confirms SupportsBIP returns true for a
+// deployment that's always in regtest's getdeploymentinfo (testdummy on
+// Core, testdummy as heretical on Inquisition).
+func TestRPC_SupportsBIP_Testdummy(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	ok, err := rt.SupportsBIP(BIPTestdummy)
+	if err != nil {
+		t.Fatalf("SupportsBIP: %v", err)
+	}
+	if !ok {
+		t.Error("SupportsBIP(BIPTestdummy) should be true on a regtest node")
+	}
+}
+
+// TestRPC_SupportsBIP_VariantSpecific confirms variant-specific BIPs resolve
+// correctly: BIP119 should be present on Inquisition and absent on Core.
+// The test asserts whichever direction the running variant dictates.
+func TestRPC_SupportsBIP_VariantSpecific(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	v, err := rt.Variant()
+	if err != nil {
+		t.Fatalf("Variant: %v", err)
+	}
+
+	gotCTV, err := rt.SupportsBIP(BIP119)
+	if err != nil {
+		t.Fatalf("SupportsBIP(BIP119): %v", err)
+	}
+	switch v {
+	case VariantInquisition:
+		if !gotCTV {
+			t.Error("BIP119 should be present on Inquisition")
+		}
+	case VariantCore:
+		if gotCTV {
+			t.Error("BIP119 should be absent on stock Core")
+		}
+	default:
+		t.Fatalf("unexpected variant: %s", v)
+	}
+}
+
+// TestRPC_SupportsBIP_UnknownBIP pins the validation contract: passing a
+// BIPID outside the registry returns ErrUnknownBIP without touching the
+// node.
+func TestRPC_SupportsBIP_UnknownBIP(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Cleanup() })
+
+	_, err = rt.SupportsBIP(BIPUnknown)
+	if !errors.Is(err, ErrUnknownBIP) {
+		t.Errorf("SupportsBIP(BIPUnknown): want ErrUnknownBIP, got %v", err)
+	}
+	_, err = rt.SupportsBIP(BIPID(9999))
+	if !errors.Is(err, ErrUnknownBIP) {
+		t.Errorf("SupportsBIP(BIPID(9999)): want ErrUnknownBIP, got %v", err)
+	}
+}
+
+// TestRPC_MineUntilActiveBIP_UnknownBIP confirms the early-exit contract for
+// the typed wrapper: an out-of-registry BIPID returns ErrUnknownBIP without
+// mining.
+func TestRPC_MineUntilActiveBIP_UnknownBIP(t *testing.T) {
+	rt, err := New(nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Cleanup() })
+
+	_, err = rt.MineUntilActiveBIP(BIPID(9999), "addr", 100)
+	if !errors.Is(err, ErrUnknownBIP) {
+		t.Errorf("MineUntilActiveBIP(9999): want ErrUnknownBIP, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `BIPID` typed constants (`BIPTestdummy`, `BIPTaproot`, `BIP54`, `BIP118`, `BIP119`, `BIP347`, `BIP348`, `BIP349`) plus `ErrUnknownBIP` sentinel.
- Curated `bipRegistry` mapping each BIPID to its bitcoind deployment key, BIP number, name, and doc URL. Keys verified live against **Bitcoin Inquisition 29.2** (`consensuscleanup`, `anyprevout`, `checktemplateverify`, `op_cat`, `checksigfromstack`, `internalkey`).
- `ListDeployments(ctx)` returns `[]EnrichedDeployment` sorted by deployment key, joining live `getdeploymentinfo` with registry metadata. `Type` field carries the `"buried" / "bip9" / "heretical"` tag (Inquisition's signaling scheme).
- `SupportsBIP(ctx, BIPID)` — the canonical skip-when-missing primitive. Live presence check; a Core node correctly returns `false` for BIP119 even though it's in the registry.
- `MineUntilActiveBIP(ctx, BIPID, miner, maxBlocks)` — typed wrapper around the existing string-based `MineUntilActive`, additive only.

Closes #100, #101, #102.

## Test plan

- [x] `make ai-check` green (against bitcoind-inquisition on PATH).
- [x] Pure unit tests (no node):
  - `Test_BIPRegistry_Shape` — uniqueness, no zero leaks, every BIPID const present.
  - `Test_BIPID_String` — formatting (`"BIP119"`, `"testdummy"`, `"BIPUnknown"`).
  - `Test_MetaLookups` — `metaByBIP` and `metaByDeployment` round-trip.
  - `TestRPC_SupportsBIP_UnknownBIP` / `TestRPC_MineUntilActiveBIP_UnknownBIP` — `ErrUnknownBIP` early-exit.
- [x] Live tests (Core or Inquisition):
  - `TestRPC_ListDeployments` — `taproot` returned with registry metadata, output stable-sorted.
  - `TestRPC_SupportsBIP_Testdummy` — true on both variants.
  - `TestRPC_SupportsBIP_VariantSpecific` — BIP119 present on Inquisition, absent on Core (variant-aware assertion).

## Notes

- Inquisition reports a `"heretical"` deployment type (not BIP9) for the upcoming forks. `Deployment.BIP9` is nil for those entries; `EnrichedDeployment.Status` falls through to `SoftForkActive` when `Active==true`. The `Type` field surfaces the actual kind so callers can disambiguate.
- `BIPTestdummy` registry entry has `expectedVariant: VariantCore` even though Inquisition advertises a `testdummy` heretical entry — Inquisition's testdummy isn't `-vbparams`-overridable, so for activation-test purposes it's effectively Core-only. PR3's worked example will keep using the existing `Variant`-based skip pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
