### PR TITLE
add Inquisition worked example + README skip-when-missing pattern (#106, #107)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,36 @@ A lightweight Go library for managing Bitcoin Core regtest environments.
 - Bitcoin Core: `brew install bitcoin` (macOS) or `sudo apt-get install bitcoind` (Linux)
 - Go 1.23+
 
+### Optional: Bitcoin Inquisition (for upcoming soft-fork testing)
+
+[Bitcoin Inquisition](https://github.com/bitcoin-inquisition/bitcoin) is the experimental Core fork that activates the upcoming soft forks (BIP54 Consensus Cleanup, BIP118 ANYPREVOUT, BIP119 CTV, BIP347 OP_CAT, BIP348 CSFS, BIP349 INTERNALKEY). Build it once into its own directory — nothing escapes the clone, so it can't conflict with Homebrew/apt's `bitcoind`:
+
+```bash
+git clone https://github.com/bitcoin-inquisition/bitcoin.git ~/btc/bitcoin-inquisition
+cd ~/btc/bitcoin-inquisition
+cmake -B build -DBUILD_TESTS=OFF -DBUILD_GUI=OFF
+cmake --build build -j$(sysctl -n hw.ncpu)   # use $(nproc) on Linux
+```
+
+Two ways to point this library at the resulting binary:
+
+```go
+// (a) Explicit BinaryPath — recommended while iterating on a single test
+rt, _ := regtest.New(&regtest.Config{
+    BinaryPath: "/Users/you/btc/bitcoin-inquisition/build/bin/bitcoind",
+})
+
+// (b) Auto-detect — symlink it as bitcoind-inquisition on PATH and the
+//     library finds it ahead of stock bitcoind
+//
+//   ln -s ~/btc/bitcoin-inquisition/build/bin/bitcoind \
+//         /usr/local/bin/bitcoind-inquisition
+//
+//   rt, _ := regtest.New(nil)  // picks Inquisition if present
+```
+
+`rt.Variant()` reports `VariantCore` or `VariantInquisition` after Start so tests can branch on which binary is running.
+
 ## Installation
 
 ```bash
@@ -147,6 +177,29 @@ for status != regtest.SoftForkActive {
 
 For a fully-narrated walkthrough, see [`TestExampleActivateTestdummy`](examples_test.go) — the same template applies to real future soft-forks (APO/eltoo, CTV, CSFS) once you point `bitcoind` in `$PATH` at a binary that knows the deployment.
 
+#### Skip-when-missing pattern
+
+For tests that depend on an Inquisition-only deployment, use `SupportsBIP` and `t.Skip` so the same suite stays green on a Core-only machine:
+
+```go
+import "github.com/neverDefined/go-regtest"
+
+func TestMyCTVThing(t *testing.T) {
+    rt, _ := regtest.New(nil)
+    rt.Start(); defer rt.Stop()
+
+    if ok, _ := rt.SupportsBIP(regtest.BIP119); !ok {
+        t.Skip("requires bitcoind-inquisition; see README")
+    }
+
+    miner, _ := rt.GenerateBech32m("miner")
+    rt.MineUntilActiveBIP(regtest.BIP119, miner, 2000)
+    // … now build/broadcast a CTV-spending tx …
+}
+```
+
+`rt.ListDeployments()` returns the merged registry-and-live view (`BIPID`, `BIPNumber`, `Name`, `DocURL`, `Status`, `Type`, `Active`, `Height`) keyed by deployment string, useful for diagnostics. See [`TestExampleActivateBIP119`](examples_inquisition_test.go) for the full template.
+
 ### Multi-node and reorg testing
 
 For a narrated two-node fork-resolution example — partition the network, mine divergent chains, reconnect, observe Bitcoin's longest-chain rule resolve the fork — see [`TestExampleReorg`](examples_reorg_test.go).
@@ -164,6 +217,7 @@ type Config struct {
     ExtraArgs       []string // Forwarded verbatim to bitcoind on Start
     VBParams        []VBParam // BIP9 deployment configuration
     AcceptNonstdTxn bool     // -acceptnonstdtxn=1 when true
+    BinaryPath      string   // Override bitcoind binary; empty = PATH auto-detect
 }
 ```
 
@@ -179,7 +233,9 @@ type Config struct {
 
 **Addresses:** `GenerateBech32(label)`, `GenerateBech32m(label)`
 
-**Mining:** `Warp(blocks, address)`, `MineToHeight(target, address)`, `MineUntilActive(deployment, address, maxBlocks)`, `GetBlockTemplate(req)`, `SubmitBlock(block)`
+**Mining:** `Warp(blocks, address)`, `MineToHeight(target, address)`, `MineUntilActive(deployment, address, maxBlocks)`, `MineUntilActiveBIP(BIPID, address, maxBlocks)`, `GetBlockTemplate(req)`, `SubmitBlock(block)`
+
+**Soft-fork registry:** `Variant()`, `ListDeployments()`, `SupportsBIP(BIPID)`, `DeploymentStatus(name)`. Typed BIPID constants: `BIP54`, `BIP118`, `BIP119`, `BIP347`, `BIP348`, `BIP349`, `BIPTestdummy`, `BIPTaproot`.
 
 **Transactions:** `SendToAddress(address, sats)`, `GetTxOut(txid, vout, includeMempool)`, `ScanTxOutSetForAddress(address)`, `SignRawTransactionWithWallet(tx)`, `BroadcastTransaction(tx)`, `CreateRawTransaction(inputs, amounts, lockTime)`, `DecodeRawTransaction(tx)`, `DecodeScript(scriptHex)`, `FundRawTransaction(tx, opts)`, `TestMempoolAccept(txs...)`
 

--- a/examples_inquisition_test.go
+++ b/examples_inquisition_test.go
@@ -1,0 +1,122 @@
+package regtest
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestExampleActivateBIP119 is the worked example for soft-fork testing
+// against Bitcoin Inquisition. It mirrors TestExampleActivateTestdummy's
+// shape — skip-when-missing, EnsureWallet, GenerateBech32m, MineUntilActive
+// — but uses the typed BIPID surface (BIP119 / OP_CHECKTEMPLATEVERIFY) so
+// downstream tests don't have to remember Inquisition's deployment-key
+// strings ("checktemplateverify").
+//
+// Unlike testdummy on Core (which transitions DEFINED → STARTED →
+// LOCKED_IN → ACTIVE under VBParams), Inquisition activates BIP119 at
+// genesis via its "heretical" deployment scheme. So MineUntilActiveBIP
+// returns immediately with mined=0 — the API call still validates the
+// pathway end-to-end (SupportsBIP → translate BIPID → DeploymentStatus →
+// SoftForkActive) without spending blocks.
+//
+// Prerequisites:
+//   - bitcoind-inquisition on PATH (auto-detected) OR Config.BinaryPath
+//     pointing at a built Inquisition binary. See the README for build
+//     instructions.
+//
+// On a Core-only machine the test t.Skip's cleanly.
+func TestExampleActivateBIP119(t *testing.T) {
+	// 1) Start a node. Default Config relies on the PATH auto-detect chain
+	//    (bitcoind-inquisition first, fallback to bitcoind). Use a
+	//    dedicated port so this example doesn't collide with other tests.
+	rt, err := New(&Config{
+		Host:    "127.0.0.1:19850",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: filepath.Join(t.TempDir(), "regtest"),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// 2) Skip-when-missing. Core's getdeploymentinfo doesn't list
+	//    "checktemplateverify"; SupportsBIP(BIP119) returns false there
+	//    and the test skips with a clear reason. This is the canonical
+	//    pattern downstream consumers should copy for any test that needs
+	//    an Inquisition-only deployment.
+	supports, err := rt.SupportsBIPContext(ctx, BIP119)
+	if err != nil {
+		t.Fatalf("SupportsBIP(BIP119): %v", err)
+	}
+	if !supports {
+		v, _ := rt.VariantContext(ctx)
+		t.Skipf("BIP119 not advertised by this bitcoind variant (%s); see README for Inquisition install", v)
+	}
+
+	// 3) Set up a miner wallet. Coinbase rewards land here; for the
+	//    activation path on Inquisition we don't actually need them, but
+	//    keeping the wallet step makes this example a drop-in template
+	//    for tests that DO need to broadcast CTV-spending transactions.
+	if err := rt.EnsureWallet("miner"); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	miner, err := rt.GenerateBech32m("miner")
+	if err != nil {
+		t.Fatalf("GenerateBech32m: %v", err)
+	}
+
+	// 4) Inspect the initial state. On Inquisition, BIP119's deployment
+	//    record is type="heretical" with active=true since genesis. The
+	//    convenience accessor reports SoftForkActive on either Inquisition
+	//    or Core (if Core ever ships CTV-as-buried, this still works).
+	initial, err := rt.DeploymentStatusContext(ctx, "checktemplateverify")
+	if err != nil {
+		t.Fatalf("DeploymentStatus(initial): %v", err)
+	}
+	t.Logf("BIP119 initial status: %s", initial)
+
+	// 5) Drive activation. On Inquisition this short-circuits with mined=0
+	//    because the deployment is already SoftForkActive at genesis. On a
+	//    hypothetical Core build that exposes BIP119 as BIP9, the same
+	//    call would mine through the activation windows. The single line
+	//    is the whole point of the typed API:
+	mined, err := rt.MineUntilActiveBIPContext(ctx, BIP119, miner, 2000)
+	if err != nil {
+		t.Fatalf("MineUntilActiveBIP(BIP119): %v", err)
+	}
+	t.Logf("MineUntilActiveBIP(BIP119) finished after %d blocks", mined)
+
+	// 6) Final assertion. The post-condition is the same regardless of
+	//    how activation happened.
+	final, err := rt.DeploymentStatusContext(ctx, "checktemplateverify")
+	if err != nil {
+		t.Fatalf("DeploymentStatus(final): %v", err)
+	}
+	if final != SoftForkActive {
+		t.Fatalf("BIP119 final status = %s, want SoftForkActive", final)
+	}
+
+	// 7) Bonus diagnostic — log what variant we ran against and the BIP119
+	//    metadata from the registry. Useful in CI logs when triaging which
+	//    binary the suite picked up.
+	v, _ := rt.VariantContext(ctx)
+	deps, _ := rt.ListDeploymentsContext(ctx)
+	for _, d := range deps {
+		if d.BIP == BIP119 {
+			t.Logf("variant=%s BIP119 type=%s active=%v doc=%s",
+				v, d.Type, d.Active, d.DocURL)
+			return
+		}
+	}
+	// Should not reach here — SupportsBIP confirmed BIP119 was advertised.
+	t.Errorf("BIP119 missing from ListDeployments output (impossible after SupportsBIP=true)")
+}


### PR DESCRIPTION
## Summary

Closes Phase 6.0 by shipping the worked example and the README skip-when-missing pattern.

- `TestExampleActivateBIP119` (`examples_inquisition_test.go`) — narrated mirror of `TestExampleActivateTestdummy` using the typed `BIPID` surface. `t.Skip`s on Core via `SupportsBIP(BIP119)`. On Inquisition the test runs to completion: BIP119 is active at genesis (`heretical` deployment), `MineUntilActiveBIP` returns `mined=0`, final status `SoftForkActive`. Logs variant + deployment metadata for CI triage.
- `README.md`:
  - **Optional: Bitcoin Inquisition** section under Prerequisites with the in-tree `cmake` build recipe and both `Config.BinaryPath` / `bitcoind-inquisition` PATH-auto-detect snippets.
  - **Skip-when-missing pattern** under Soft-fork testing showing the canonical `SupportsBIP` + `t.Skip` idiom.
  - `Config` table updated with `BinaryPath`.
  - API Reference: `MineUntilActiveBIP` and a new "Soft-fork registry" line listing `Variant`, `ListDeployments`, `SupportsBIP`, and the typed BIPID constants.

Closes #106, #107.

## Test plan

- [x] `make ai-check` green (against `bitcoind-inquisition` on PATH).
- [x] `TestExampleActivateBIP119` passes on Inquisition. Test output:
  ```
  BIP119 initial status: active
  MineUntilActiveBIP(BIP119) finished after 0 blocks
  variant=inquisition BIP119 type=heretical active=true doc=https://github.com/bitcoin/bips/blob/master/bip-0119.mediawiki
  ```
- [x] On a Core-only machine the test `t.Skip`s with: "BIP119 not advertised by this bitcoind variant (core); see README for Inquisition install" — no further work.
- [x] README renders cleanly; skip-pattern snippet is copy-paste-compilable (uses only public API).

## Notes

- The example's "activation" is trivial on Inquisition because the deployment is active at genesis. The point isn't to observe the BIP9 state machine (Core's testdummy already does that) — it's to be a drop-in template for downstream tests that want to broadcast CTV/APO/CSFS-spending transactions and skip cleanly on Core.
- README copy uses `~/btc/bitcoin-inquisition` as the example clone path because the maintainer's machine uses that layout. Substitute any path; the build instructions are clone-relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
