### PR TITLE
add timeout-without-lockin and variant detection examples (#108, #109)

### DIFF
--- a/examples_inquisition_test.go
+++ b/examples_inquisition_test.go
@@ -120,3 +120,42 @@ func TestExampleActivateBIP119(t *testing.T) {
 	// Should not reach here — SupportsBIP confirmed BIP119 was advertised.
 	t.Errorf("BIP119 missing from ListDeployments output (impossible after SupportsBIP=true)")
 }
+
+// TestVariantDetection is the smoke test for Variant(): start a node, assert
+// the variant resolves to Core or Inquisition (not Unknown — Unknown means
+// the subversion parser regressed), and log the value so CI output records
+// which binary the suite ran against.
+//
+// Whichever bitcoind happens to be on PATH (or whatever Config.BinaryPath
+// points at) is a valid answer; the test pins only that the parse path
+// succeeds and the variant is one of the known good values.
+func TestVariantDetection(t *testing.T) {
+	rt, err := New(&Config{
+		Host:    "127.0.0.1:19852",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: filepath.Join(t.TempDir(), "regtest"),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	v, err := rt.Variant()
+	if err != nil {
+		t.Fatalf("Variant: %v", err)
+	}
+	t.Logf("running against variant: %s (binary: %s)", v, rt.bitcoindPath)
+
+	switch v {
+	case VariantCore, VariantInquisition:
+		// Either is a valid runtime answer.
+	case VariantUnknown:
+		t.Errorf("Variant() returned VariantUnknown — getnetworkinfo subversion parser regressed?")
+	default:
+		t.Errorf("Variant() returned unrecognized value: %d", v)
+	}
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -3,6 +3,7 @@ package regtest
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -224,4 +225,119 @@ func TestExampleActivateTestdummy(t *testing.T) {
 			maxWindows, final, observed)
 	}
 	t.Logf("testdummy activated successfully — observed transitions: %v", observed)
+}
+
+// TestExampleTimeoutWithoutLockin is the worked example for the BIP9 failure
+// path: a deployment whose timeout passes before the signaling threshold is
+// met transitions to SoftForkFailed. The Phase 6 time API (WarpTime + sticky
+// mocktime) makes this observable in seconds rather than waiting through
+// real-world time.
+//
+// On Bitcoin Core's BIP9 state machine, the transitions are:
+//
+//	at boundary 144:  DEFINED → STARTED   (MTP >= start_time)
+//	at boundary 288:  STARTED → FAILED    (MTP >= timeout, no lock-in)
+//
+// So we need to mine to height 288 with MTP past the configured timeout.
+// This test sets a far-future timeout, uses WarpTime to push MTP past it,
+// then mines through the second retarget boundary.
+//
+// Inquisition replaces BIP9 with its "heretical" state machine which doesn't
+// honor -vbparams overrides for testdummy, so the test skips there. PR2's
+// SupportsBIP could substitute once we add a BIP for testdummy, but the
+// Variant check is sufficient and self-documenting.
+func TestExampleTimeoutWithoutLockin(t *testing.T) {
+	const timeout = 4_000_000_000 // year ~2096; under the uint32 block-timestamp cap
+
+	cfg := &Config{
+		Host:    "127.0.0.1:19851",
+		User:    "user",
+		Pass:    "pass",
+		DataDir: filepath.Join(t.TempDir(), "regtest"),
+		// -blockversion=0x20000000 (536870912) is the BIP9 baseline with no
+		// deployment bits set. Without it, regtest's default block-version
+		// policy signals for every STARTED deployment, so testdummy would
+		// LOCKED_IN before the timeout check (Bitcoin Core's BIP9 evaluates
+		// signaling threshold before the timeout). Suppressing signaling is
+		// the only way to demonstrate the FAILED transition.
+		ExtraArgs: []string{"-blockversion=536870912"},
+		VBParams: []VBParam{{
+			Deployment:          "testdummy",
+			StartTime:           0,
+			Timeout:             timeout,
+			MinActivationHeight: 0,
+		}},
+		AcceptNonstdTxn: true,
+	}
+	rt, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := rt.Start(); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer rt.Stop()
+
+	if v, _ := rt.Variant(); v == VariantInquisition {
+		t.Skip("testdummy not driveable via -vbparams on Inquisition (heretical state machine)")
+	}
+
+	if err := rt.EnsureWallet("miner"); err != nil {
+		t.Fatalf("EnsureWallet: %v", err)
+	}
+	miner, err := rt.GenerateBech32("miner")
+	if err != nil {
+		t.Fatalf("GenerateBech32: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	// Pre-fill 11 blocks so MTP has a populated window before we warp.
+	if err := rt.WarpContext(ctx, 11, miner); err != nil {
+		t.Fatalf("Warp pre-fill: %v", err)
+	}
+
+	initial, err := rt.DeploymentStatusContext(ctx, "testdummy")
+	if err != nil {
+		t.Fatalf("DeploymentStatus initial: %v", err)
+	}
+	t.Logf("initial status: %s", initial)
+	if initial == SoftForkFailed {
+		t.Fatalf("testdummy started in SoftForkFailed; expected DEFINED/STARTED on a pre-warp chain")
+	}
+
+	// Compute a duration that pushes MTP comfortably past timeout regardless
+	// of system time. WarpTime sets mocktime sticky, so subsequent Warp /
+	// MineToHeight calls also stamp blocks at the warped time — keeping the
+	// MTP window populated past timeout for the BIP9 evaluation at 288.
+	preInfo, err := rt.GetBlockChainInfoContext(ctx)
+	if err != nil {
+		t.Fatalf("GetBlockChainInfo: %v", err)
+	}
+	need := time.Duration(timeout-preInfo.MedianTime+86400) * time.Second // +1 day cushion
+	newMTP, err := rt.WarpTimeContext(ctx, need, miner)
+	if err != nil {
+		t.Fatalf("WarpTime: %v", err)
+	}
+	t.Logf("warped MTP from %d to %d (timeout=%d)", preInfo.MedianTime, newMTP, timeout)
+	if newMTP < timeout {
+		t.Fatalf("WarpTime produced MTP=%d, still below timeout=%d", newMTP, timeout)
+	}
+
+	// Mine to the second retarget boundary so BIP9 evaluates STARTED → FAILED.
+	// Mocktime is still set from WarpTime, so all new blocks stamp at the
+	// warped time — MTP at 288 stays past timeout.
+	if err := rt.MineToHeightContext(ctx, 288, miner); err != nil {
+		t.Fatalf("MineToHeight 288: %v", err)
+	}
+
+	final, err := rt.DeploymentStatusContext(ctx, "testdummy")
+	if err != nil {
+		t.Fatalf("DeploymentStatus final: %v", err)
+	}
+	t.Logf("final status at height 288: %s", final)
+	if final != SoftForkFailed {
+		t.Fatalf("testdummy final status = %s, want SoftForkFailed", final)
+	}
 }

--- a/time.go
+++ b/time.go
@@ -11,6 +11,14 @@ import (
 // in an int64; this number is roughly the year 2262.
 const maxMockTime int64 = 9_223_372_036
 
+// maxBlockTime is the cap for any timestamp that ends up in a Bitcoin block
+// header. The header's nTime field is uint32, so values above this overflow
+// when bitcoind constructs a block — generatetoaddress then rejects the
+// freshly-built block with the cryptic "time-too-old" error. MineWithTimestamp
+// and WarpTime validate against this limit so callers get an immediate,
+// actionable error instead. Equivalent to year 2106.
+const maxBlockTime int64 = 4_294_967_295
+
 // mtpWindow is the number of blocks Bitcoin Core averages to compute Median
 // Time Past (BIP113). Mining mtpWindow + 1 blocks at the same timestamp is
 // the simplest way to drag MTP forward to that timestamp — see WarpTime.
@@ -109,6 +117,12 @@ func (r *Regtest) MineWithTimestampContext(ctx context.Context, blocks, unix int
 	if miner == "" {
 		return fmt.Errorf("MineWithTimestamp: miner must be provided")
 	}
+	// Stricter than SetMockTime's range: block.nTime is uint32, so anything
+	// above maxBlockTime overflows when bitcoind constructs the block and
+	// generatetoaddress fails with "time-too-old". Catch it up front.
+	if unix > maxBlockTime {
+		return fmt.Errorf("MineWithTimestamp: unix must be ≤ %d (uint32 block timestamp cap, ~year 2106), got %d", maxBlockTime, unix)
+	}
 	if err := r.SetMockTimeContext(ctx, unix); err != nil {
 		return err
 	}
@@ -154,8 +168,9 @@ func (r *Regtest) WarpTime(duration time.Duration, miner string) (int64, error) 
 //
 // Returns:
 //   - newMTP: chain mediantime after the warp.
-//   - error: validation error; errNotConnected before Start; ctx.Err() on
-//     cancellation; wrapped RPC error otherwise.
+//   - error: validation error (including target > uint32 cap of year 2106);
+//     errNotConnected before Start; ctx.Err() on cancellation; wrapped RPC
+//     error otherwise.
 func (r *Regtest) WarpTimeContext(ctx context.Context, duration time.Duration, miner string) (int64, error) {
 	if duration <= 0 {
 		return 0, fmt.Errorf("WarpTime: duration must be > 0, got %s", duration)
@@ -169,6 +184,10 @@ func (r *Regtest) WarpTimeContext(ctx context.Context, duration time.Duration, m
 		return 0, fmt.Errorf("WarpTime: read tip: %w", err)
 	}
 	target := info.MedianTime + int64(duration.Seconds())
+	if target > maxBlockTime {
+		return 0, fmt.Errorf("WarpTime: target %d exceeds uint32 block-timestamp cap %d (~year 2106); pick a smaller duration",
+			target, maxBlockTime)
+	}
 
 	// Mine mtpWindow + 1 blocks all stamped at target. After mtpWindow + 1
 	// fresh blocks, the most recent mtpWindow are all at target so the new


### PR DESCRIPTION
## Summary

Closes Phase 6.1. Two final worked examples plus a small validation hardening of `time.go` that surfaced during development.

### `TestExampleTimeoutWithoutLockin` (closes #108)

Narrated mirror of `TestExampleActivateTestdummy` for the BIP9 FAILED path. Uses `WarpTime` to drag MTP past a configured timeout, then mines to the second retarget boundary where Bitcoin Core evaluates `STARTED → FAILED`.

Two non-obvious recipe details surfaced and are documented inline:

- **Signaling-vs-timeout precedence.** Core's BIP9 checks the signaling threshold *before* the timeout check, and regtest's default block-version policy signals every STARTED deployment automatically. Without intervention, testdummy would `LOCKED_IN` before timeout could fire. The test passes `-blockversion=0x20000000` (BIP9 baseline with no deployment bits set) via `ExtraArgs` to suppress signaling so the FAILED path is reachable.
- **uint32 block-timestamp cap.** Block headers store `nTime` as `uint32`, max `4_294_967_295` (year 2106). Setting mocktime above this cap causes `generatetoaddress` to fail with a cryptic `time-too-old` error (the value overflows). The test uses `timeout = 4_000_000_000` (year 2096) — comfortably under the cap.

Skips on Inquisition, where testdummy is a `heretical` deployment that isn't `-vbparams`-overridable.

### `TestVariantDetection` (closes #109)

Smoke test that `Variant()` resolves to `VariantCore` or `VariantInquisition` (not the zero-value `VariantUnknown` — that would indicate a `getnetworkinfo.subversion` parser regression). Logs the detected variant and binary path so CI output records which build the suite ran against.

### `time.go` — uint32 cap validation

Surfaced by the timeout test work. Added `maxBlockTime` constant (`4_294_967_295`) and validation:

- `MineWithTimestampContext` rejects `unix > maxBlockTime` up front with a clear message.
- `WarpTimeContext` rejects `target > maxBlockTime` up front.

Both methods' godoc updated. Existing `SetMockTime` keeps the looser `maxMockTime = 9_223_372_036` cap (matches Core's RPC validation) since you can call `setmocktime` for non-mining purposes.

## Test plan

- [x] `make ai-check` green (against `bitcoind-inquisition` on PATH).
- [x] `TestVariantDetection` passes on Inquisition (logs `running against variant: inquisition`).
- [x] `TestExampleTimeoutWithoutLockin` `t.Skip`s cleanly on Inquisition.
- [x] On Core (verified via temporary `BinaryPath`-override probe): `TestExampleTimeoutWithoutLockin` runs to completion with `final status: failed`. Probe was deleted before commit.

## Notes

- Closes Phase 6.1 milestone. With #115 merged and this PR, all 13 issues across both Phase 6 milestones (#97–#109) are closed. Tracking issue #110 can be closed too.
- The `-blockversion` workaround is regtest-only (`MineBlocksOnDemand()` gates the override). On mainnet/testnet it's a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
