### PR TITLE
docs: link worked examples from doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -89,6 +89,26 @@ Direct RPC Access:
 	info, _ := client.GetBlockChainInfo()
 	mempool, _ := client.GetRawMempool()
 
+# Worked Examples
+
+Narrated end-to-end examples — each one is a runnable test that downstream
+consumers can use as a copy-paste template:
+
+  - TestExampleActivateTestdummy (examples_test.go) — drive Core's testdummy
+    deployment through the BIP9 state machine (DEFINED → STARTED → LOCKED_IN →
+    ACTIVE). Skips on Inquisition.
+  - TestExampleTimeoutWithoutLockin (examples_test.go) — the FAILED path:
+    suppress signaling via -blockversion, use WarpTime to drag MTP past the
+    configured timeout, observe STARTED → FAILED at the second retarget
+    boundary. Skips on Inquisition.
+  - TestExampleActivateBIP119 (examples_inquisition_test.go) — Inquisition
+    template: SupportsBIP skip-when-missing + MineUntilActiveBIP, asserts
+    BIP119 / OP_CHECKTEMPLATEVERIFY ends SoftForkActive.
+  - TestVariantDetection (examples_inquisition_test.go) — smoke test that
+    Variant() resolves correctly against whichever bitcoind is on PATH.
+  - TestExampleReorg (examples_reorg_test.go) — two-node fork resolution:
+    partition, mine divergent chains, reconnect, observe longest-chain rule.
+
 # Soft-fork Testing
 
 VBParams configure named BIP9 deployments via -vbparams. DeploymentStatus and


### PR DESCRIPTION
## Summary

Pure docs follow-up to Phase 6. Adds a "Worked Examples" pointer section to `doc.go` that names each narrated test with a one-line description, so pkg.go.dev readers can find the runnable templates.

Tests linked:
- `TestExampleActivateTestdummy` (BIP9 ACTIVE path on Core)
- `TestExampleTimeoutWithoutLockin` (BIP9 FAILED path via `WarpTime`)
- `TestExampleActivateBIP119` (Inquisition skip-when-missing template)
- `TestVariantDetection` (Core/Inquisition smoke test)
- `TestExampleReorg` (two-node fork resolution)

No code changes.

## Test plan

- [x] `make ai-check` green.
- [x] `go doc github.com/neverDefined/go-regtest` shows the new section before "Soft-fork Testing".

🤖 Generated with [Claude Code](https://claude.com/claude-code)